### PR TITLE
chore: exclude `.github` folder from bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.github/**
 .vscode/**
 .vscode-test/**
 src/**


### PR DESCRIPTION
The extension currently ships with the `.github` folder
![image](https://github.com/user-attachments/assets/f2731d95-e736-4413-83e6-52e314caada9)
