### PR TITLE
fix: Add RegEx `s` flag to handle any new-line chars.

### DIFF
--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -109,7 +109,7 @@ export const runInLaravel = <T>(
                 toTemplateVar("start_output") +
                     "(.*)" +
                     toTemplateVar("end_output"),
-                "g",
+                "gs",
             );
 
             const out = regex.exec(result);


### PR DESCRIPTION
This PR adds the support for the `runPhp` to handle new-line chars.

I had that problem on a project that gave me this error:

<img width="619" alt="image" src="https://github.com/user-attachments/assets/8f1099d7-3a3d-4179-8461-6e02636386ac" />

<img width="824" alt="image" src="https://github.com/user-attachments/assets/1c7c5303-a248-45c6-aca1-f412816bfb45" />

After debugging it, I did found out, it was the missing `s` flag on the regex.

Hope that helps,
Cheers,
Francisco.