### PR TITLE
Fixes: Can't find parser binary on windows when path has spaces

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -31,7 +31,6 @@ export const setParserBinaryPath = (context: vscode.ExtensionContext) => {
     downloadBinary(context).then((path) => {
         if (path) {
             parserBinaryPath = process.env.PHP_PARSER_BINARY_PATH || path;
-            parserBinaryPath = path.replace(" ", "\\ ");
         }
     });
 };
@@ -170,7 +169,7 @@ const runCommand = (command: string): Promise<string> => {
         }
 
         const extraArgs = os.platform() === "win32" ? "--from-file" : "";
-        const toRun = `${parserBinaryPath} ${command} ${extraArgs}`;
+        const toRun = `"${parserBinaryPath}" ${command} ${extraArgs}`;
 
         // console.log("running command", toRun);
 


### PR DESCRIPTION
Fixes #135 . 
The shell interprets spaces as delimiter except when the path is surrounded by double quotes.

Escaping the spaces with Line 34 does not work.

FYI: I also I had to remove the `PHP_PARSER_BINARY_PATH` from env at `launch.json` to be able to work on this on windows since the priority is to the `.env.PHP_PARSER_BINARY_PATH` not the generated path.

I have not tested this on other platforms so I dont know if it broke something.
