### PR TITLE
feat: add configurable Inertia page path

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,6 +247,12 @@
                     "generated": true,
                     "description": null
                 },
+                "Laravel.inertia.path": {
+                    "type": "string",
+                    "default": "resources/js/Pages",
+                    "generated": true,
+                    "description": "Path to Inertia pages."
+                },
                 "Laravel.middleware.diagnostics": {
                     "type": "boolean",
                     "default": true,

--- a/src/features/inertia.ts
+++ b/src/features/inertia.ts
@@ -154,8 +154,10 @@ export const codeActionProvider: CodeActionProviderFunction = async (
         break;
     }
 
+    const path = config("inertia.path", "resources/js/Pages");
+
     const fileUri = vscode.Uri.file(
-        projectPath(`resources/js/Pages/${missingFilename}.${extension}`),
+        projectPath(`${path}/${missingFilename}.${extension}`),
     );
 
     const edit = new vscode.WorkspaceEdit();

--- a/src/repositories/inertia.ts
+++ b/src/repositories/inertia.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { repository } from ".";
 import { View } from "..";
 import { projectPath, relativePath } from "./../support/project";
+import { config } from "./../support/config";
 
 interface ViewItem {
     [key: string]: View;
@@ -12,7 +13,7 @@ interface ViewItem {
 const load = (pagePaths: string[], validExtensions: string[]) => {
     let views: ViewItem = {};
 
-    pagePaths = pagePaths.length > 0 ? pagePaths : ["/resources/js/Pages"];
+    pagePaths = pagePaths.length > 0 ? pagePaths : [config("inertia.path", "resources/js/Pages")];
 
     pagePaths
         .map((path) => "/" + relativePath(path))
@@ -83,7 +84,7 @@ export const getInertiaViews = repository<ViewItem>(
                 result?.page_extensions ?? [],
             );
         }),
-    "{,**/}{resources/js/Pages}/{*,**/*}",
+    `{,**/}{${config("inertia.path", "resources/js/Pages")}}/{*,**/*}`,
     {},
     ["create", "delete"],
 );

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -4,6 +4,7 @@ import { GeneratedConfigKey } from "./generated-config";
 type ConfigKey =
     | GeneratedConfigKey
     | "phpCommand"
+    | "inertia.path"
     | "tests.docker.enabled"
     | "tests.ssh.enabled"
     | "tests.suiteSuffix"


### PR DESCRIPTION
- Introduced a new configuration key "inertia.path" in package.json to allow customization of the Inertia pages directory.
- Updated inertia.ts and repositories/inertia.ts to utilize the new configuration for dynamic path resolution.
- Ensured backward compatibility by providing a default value for the path.

Fixes https://github.com/laravel/vs-code-extension/issues/151 