### PR TITLE
Debounce repo refresh

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import { hoverProviders } from "./hover/HoverProvider";
 import { linkProviders } from "./link/LinkProvider";
 import { info } from "./support/logger";
 import { setParserBinaryPath } from "./support/parser";
-import { initDiscoverFiles } from "./support/php";
+import { initVendorWatchers } from "./support/php";
 import { hasWorkspace, projectPathExists } from "./support/project";
 import { cleanUpTemp } from "./support/util";
 
@@ -57,7 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
         { scheme: "file", language: "laravel-blade" },
     ];
 
-    initDiscoverFiles();
+    initVendorWatchers();
     setParserBinaryPath(context);
 
     const TRIGGER_CHARACTERS = ["'", '"'];

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { getWorkspaceFolders, hasWorkspace } from "./project";
+import { debounce } from "./util";
 
 type FileEvent = "change" | "create" | "delete";
 
@@ -18,7 +19,7 @@ export const loadAndWatch = (
 
     load();
 
-    createFileWatcher(patterns, load, events);
+    createFileWatcher(patterns, debounce(load, 500), events);
 };
 
 export const createFileWatcher = (
@@ -35,6 +36,9 @@ export const createFileWatcher = (
     return patterns.map((pattern) => {
         const watcher = vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern(getWorkspaceFolders()[0], pattern),
+            !events.includes("create"),
+            !events.includes("change"),
+            !events.includes("delete"),
         );
 
         if (events.includes("change")) {

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -19,7 +19,7 @@ export const loadAndWatch = (
 
     load();
 
-    createFileWatcher(patterns, debounce(load, 500), events);
+    createFileWatcher(patterns, debounce(load, 750), events);
 };
 
 export const createFileWatcher = (

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -10,6 +10,7 @@ import {
     internalVendorPath,
     projectPath,
     projectPathExists,
+    setInternalVendorExists,
 } from "./project";
 import { md5 } from "./util";
 
@@ -30,6 +31,8 @@ export const initDiscoverFiles = () => {
 
     const watcher = vscode.workspace.createFileSystemWatcher(
         new vscode.RelativePattern(internalVendorPath(), "discover-*"),
+        true,
+        true,
     );
 
     watcher.onDidDelete((file) => {
@@ -39,6 +42,21 @@ export const initDiscoverFiles = () => {
                 break;
             }
         }
+    });
+
+    const onVendorDelete = () => {
+        setInternalVendorExists(false);
+        discoverFiles.clear();
+    };
+
+    [internalVendorPath(), projectPath("vendor")].forEach((path) => {
+        const watcher = vscode.workspace.createFileSystemWatcher(
+            path,
+            true,
+            true,
+        );
+
+        watcher.onDidDelete(onVendorDelete);
     });
 };
 

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -22,7 +22,10 @@ let defaultPhpCommand: string | null = null;
 
 const discoverFiles = new Map<string, string>();
 
-export const initDiscoverFiles = () => {
+let hasVendor = projectPathExists("vendor/autoload.php");
+const hasBootstrap = projectPathExists("bootstrap/app.php");
+
+export const initVendorWatchers = () => {
     // fs.readdirSync(internalVendorPath()).forEach((file) => {
     //     if (file.startsWith("discover-")) {
     //         fs.unlinkSync(internalVendorPath(file));
@@ -44,11 +47,6 @@ export const initDiscoverFiles = () => {
         }
     });
 
-    const onVendorDelete = () => {
-        setInternalVendorExists(false);
-        discoverFiles.clear();
-    };
-
     [internalVendorPath(), projectPath("vendor")].forEach((path) => {
         const watcher = vscode.workspace.createFileSystemWatcher(
             path,
@@ -56,7 +54,25 @@ export const initDiscoverFiles = () => {
             true,
         );
 
-        watcher.onDidDelete(onVendorDelete);
+        watcher.onDidDelete(() => {
+            setInternalVendorExists(false);
+            discoverFiles.clear();
+            hasVendor = false;
+        });
+    });
+
+    const autoloadWatcher = vscode.workspace.createFileSystemWatcher(
+        projectPath("vendor/autoload.php"),
+        false,
+        true,
+    );
+
+    autoloadWatcher.onDidCreate(() => {
+        hasVendor = true;
+    });
+
+    autoloadWatcher.onDidDelete(() => {
+        hasVendor = false;
     });
 };
 
@@ -127,16 +143,22 @@ export const template = (
     return templateString;
 };
 
-const hasVendor = projectPathExists("vendor/autoload.php");
-const hasBootstrap = projectPathExists("bootstrap/app.php");
-
 export const runInLaravel = <T>(
     code: string,
     description: string | null = null,
     asJson: boolean = true,
+    tryCount = 0,
 ): Promise<T> => {
     if (!hasVendor) {
-        throw new Error("Vendor autoload not found, run composer install");
+        if (tryCount >= 30) {
+            throw new Error("Vendor autoload not found, run composer install");
+        }
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(runInLaravel(code, description, asJson, tryCount + 1));
+            }, 1000);
+        });
     }
 
     if (!hasBootstrap) {

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -4,6 +4,10 @@ import * as vscode from "vscode";
 
 let internalVendorExists: boolean | null = null;
 
+export const setInternalVendorExists = (value: boolean) => {
+    internalVendorExists = value;
+};
+
 export const internalVendorPath = (subPath = ""): string => {
     const baseDir = path.join("vendor", "_laravel_ide");
 

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -58,3 +58,18 @@ export const cleanUpTemp = () => {
         fs.rmdirSync(tempDir, { recursive: true });
     }
 };
+
+export const debounce = <T extends (...args: any[]) => any>(
+    func: T,
+    wait: number,
+): T => {
+    let timeout: NodeJS.Timeout;
+
+    return function (this: any, ...args: any[]) {
+        clearTimeout(timeout);
+
+        timeout = setTimeout(() => {
+            func.apply(this, args);
+        }, wait);
+    } as T;
+};


### PR DESCRIPTION
This PR debounces the call to refresh the individual item repos to prevent additional load on the machine when running a command such as `composer install`. Hopefully fixes #127.