### PR TITLE
Removed hardcoded local paths from launch ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Local path to the PHP Parser binary
+PHP_PARSER_BINARY_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 .DS_Store
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,7 @@
 // Use IntelliSense to learn about possible attributes.
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-// Local Phar: /Users/joetannenbaum/Dev/vs-code/parser-zero/builds/php-parser`;
-// Local Bin: /Users/joetannenbaum/Dev/vs-code/parser-zero/bin/php-parser`;
-// Local Live: /Users/joetannenbaum/Dev/vs-code/parser-zero/php-parser`;
+
 {
     "version": "0.2.0",
     "configurations": [
@@ -20,9 +18,7 @@
                 "${workspaceFolder}/**/*.ts"
             ],
             "preLaunchTask": "${defaultBuildTask}",
-            "env": {
-                "PHP_PARSER_BINARY_PATH": "/Users/joetannenbaum/Dev/vs-code/parser-zero/php-parser"
-            }
+            "envFile": "${workspaceFolder}/.env"
         }
     ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,3 +19,5 @@ esbuild.js
 generatable.json
 php-templates
 checkBinaryVersion
+.env
+.env.example


### PR DESCRIPTION
This PR removes my hardcoded local paths from the `launch.json` and swaps them with an optional `.env` file (sorry).

This will make it easier for others to contribute to the extension and reduce confusion.