### PR TITLE
Preconfigured PHP environment setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,7 @@
         "configuration": {
             "title": "Laravel",
             "properties": {
-                "Laravel.phpCommand": {
-                    "type": "string",
-                    "description": "Template for running PHP code. Use {code} as a placeholder for the code file to run. e.g. `php \"{code}\"`"
-                },
-                "Laravel.localPhp": {
+                "Laravel.phpEnvironment": {
                     "type": "string",
                     "enum": [
                         "auto",
@@ -92,13 +88,17 @@
                     ],
                     "markdownEnumDescriptions": [
                         "Auto detect the local PHP environment.",
-                        "Detect PHP version Herd is using for the project.",
-                        "Valet",
+                        "Auto detect PHP version Herd is using for the project.",
+                        "Auto detect PHP version Valet is using for the project.",
                         "Sail",
-                        "PHP is installed on the local machine."
+                        "Use PHP installed on the local machine."
                     ],
                     "default": "auto",
-                    "description": "Local PHP environment, leave on 'auto' and configure the 'PHP Command' setting to configure a custom local PHP setup."
+                    "markdownDescription": "Local PHP environment. If you have a value for `#Laravel.phpCommand#` this setting will be ignored and that value will be used instead."
+                },
+                "Laravel.phpCommand": {
+                    "type": "string",
+                    "description": "Template for running PHP code. Use {code} as a placeholder for the php file to run. e.g. `php \"{code}\"`"
                 },
                 "Laravel.showErrorPopups": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,32 @@
                     "type": "string",
                     "description": "Template for running PHP code. Use {code} as a placeholder for the code file to run. e.g. `php \"{code}\"`"
                 },
+                "Laravel.localPhp": {
+                    "type": "string",
+                    "enum": [
+                        "auto",
+                        "herd",
+                        "valet",
+                        "sail",
+                        "local"
+                    ],
+                    "enumItemLabels": [
+                        "Auto Detect",
+                        "Herd",
+                        "Valet",
+                        "Sail",
+                        "Local"
+                    ],
+                    "markdownEnumDescriptions": [
+                        "Auto detect the local PHP environment.",
+                        "Detect PHP version Herd is using for the project.",
+                        "Valet",
+                        "Sail",
+                        "PHP is installed on the local machine."
+                    ],
+                    "default": "auto",
+                    "description": "Local PHP environment, leave on 'auto' and configure the 'PHP Command' setting to configure a custom local PHP setup."
+                },
                 "Laravel.showErrorPopups": {
                     "type": "boolean",
                     "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     vscode.workspace.onDidChangeConfiguration((event) => {
-        if (configAffected(event, "phpCommand", "localPhp")) {
+        if (configAffected(event, "phpCommand", "phpEnvironment")) {
             clearDefaultPhpCommand();
         }
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,9 +15,10 @@ import ValidationCompletion from "./completion/Validation";
 import { updateDiagnostics } from "./diagnostic/diagnostic";
 import { hoverProviders } from "./hover/HoverProvider";
 import { linkProviders } from "./link/LinkProvider";
+import { configAffected } from "./support/config";
 import { info } from "./support/logger";
 import { setParserBinaryPath } from "./support/parser";
-import { initVendorWatchers } from "./support/php";
+import { clearDefaultPhpCommand, initVendorWatchers } from "./support/php";
 import { hasWorkspace, projectPathExists } from "./support/project";
 import { cleanUpTemp } from "./support/util";
 
@@ -131,6 +132,12 @@ export function activate(context: vscode.ExtensionContext) {
         ),
         vscode.commands.registerCommand("laravel.open", openFileCommand),
     );
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+        if (configAffected(event, "phpCommand", "localPhp")) {
+            clearDefaultPhpCommand();
+        }
+    });
 }
 
 export function deactivate() {

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -3,6 +3,7 @@ import { GeneratedConfigKey } from "./generated-config";
 
 type ConfigKey =
     | GeneratedConfigKey
+    | "localPhp"
     | "phpCommand"
     | "tests.docker.enabled"
     | "tests.ssh.enabled"
@@ -11,3 +12,12 @@ type ConfigKey =
 
 export const config = <T>(key: ConfigKey, fallback: T): T =>
     vscode.workspace.getConfiguration("Laravel").get<T>(key, fallback);
+
+export const configKey = <T>(key: ConfigKey): string => `Laravel.${key}`;
+
+export const configAffected = (
+    event: vscode.ConfigurationChangeEvent,
+    ...keys: ConfigKey[]
+): boolean => keys.some((key) => event.affectsConfiguration(configKey(key)));
+
+export type LocalPhpInstallation = "auto" | "herd" | "valet" | "sail" | "local";

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -3,7 +3,7 @@ import { GeneratedConfigKey } from "./generated-config";
 
 type ConfigKey =
     | GeneratedConfigKey
-    | "localPhp"
+    | "phpEnvironment"
     | "phpCommand"
     | "tests.docker.enabled"
     | "tests.ssh.enabled"
@@ -20,4 +20,4 @@ export const configAffected = (
     ...keys: ConfigKey[]
 ): boolean => keys.some((key) => event.affectsConfiguration(configKey(key)));
 
-export type LocalPhpInstallation = "auto" | "herd" | "valet" | "sail" | "local";
+export type PhpEnvironment = "auto" | "herd" | "valet" | "sail" | "local";

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -1,15 +1,16 @@
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as vscode from "vscode";
-import { TemplateName, getTemplate } from "../templates";
-import { config } from "./config";
-import { error } from "./logger";
+import { getTemplate, TemplateName } from "../templates";
+import { config, LocalPhpInstallation } from "./config";
+import { error, info } from "./logger";
 import { showErrorPopup } from "./popup";
 import {
     getWorkspaceFolders,
     internalVendorPath,
     projectPath,
     projectPathExists,
+    relativePath,
     setInternalVendorExists,
 } from "./project";
 import { md5 } from "./util";
@@ -24,6 +25,11 @@ const discoverFiles = new Map<string, string>();
 
 let hasVendor = projectPathExists("vendor/autoload.php");
 const hasBootstrap = projectPathExists("bootstrap/app.php");
+
+let localPhpKey: LocalPhpInstallation | null = null;
+const localPhpInstallationsThatUseRelativePaths: LocalPhpInstallation[] = [
+    "sail",
+];
 
 export const initVendorWatchers = () => {
     // fs.readdirSync(internalVendorPath()).forEach((file) => {
@@ -77,22 +83,38 @@ export const initVendorWatchers = () => {
 };
 
 const getPhpCommand = (): string => {
-    const options = [
-        {
-            check: "herd which-php",
-            command: "{binaryPath}",
-        },
-        {
-            check: "php -r 'echo PHP_BINARY;'",
-            command: "{binaryPath}",
-        },
-        {
-            check: `${projectPath("vendor/bin/sail")} ps`,
-            command: `${projectPath("vendor/bin/sail")} php`,
-        },
-    ];
+    const localPhp = config<LocalPhpInstallation>("localPhp", "auto");
 
-    for (const option of options) {
+    const options = new Map<
+        LocalPhpInstallation,
+        { check: string | string[]; command: string }
+    >();
+
+    options.set("herd", {
+        check: "herd which-php",
+        command: `"{binaryPath}"`,
+    });
+
+    options.set("valet", {
+        check: "valet which-php",
+        command: `"{binaryPath}"`,
+    });
+
+    options.set("local", {
+        check: "php -r 'echo PHP_BINARY;'",
+        command: `"{binaryPath}"`,
+    });
+
+    options.set("sail", {
+        check: "./vendor/bin/sail ps",
+        command: "./vendor/bin/sail php",
+    });
+
+    for (const [key, option] of options.entries()) {
+        if (localPhp !== "auto" && localPhp !== key) {
+            continue;
+        }
+
         try {
             const checks = Array.isArray(option.check)
                 ? option.check
@@ -101,27 +123,40 @@ const getPhpCommand = (): string => {
             let result = "";
 
             while (check) {
+                info(`Checking ${key} PHP installation: ${check}`);
+
                 result = cp
-                    .execSync(check)
+                    .execSync(check, {
+                        cwd: projectPath(""),
+                    })
                     .toString()
                     .trim()
-                    .replace("{binaryPath}", result.replace(/ /g, "\\ "));
+                    .replace("{binaryPath}", result);
 
                 check = checks.shift();
             }
 
             if (result !== "") {
-                return option.command.replace(
-                    "{binaryPath}",
-                    result.replace(/ /g, "\\ "),
-                );
+                info(`Using ${key} PHP installation: ${result}`);
+
+                localPhpKey = key;
+
+                return option.command.replace("{binaryPath}", result);
             }
         } catch (e) {
             // ignore
         }
     }
 
+    info("Falling back to system PHP installation");
+
+    localPhpKey = "local";
+
     return "php";
+};
+
+export const clearDefaultPhpCommand = () => {
+    defaultPhpCommand = null;
 };
 
 const getDefaultPhpCommand = (): string => {
@@ -211,9 +246,17 @@ export const runInLaravel = <T>(
         });
 };
 
+const fixFilePath = (path: string) => {
+    if (localPhpInstallationsThatUseRelativePaths.includes(localPhpKey!)) {
+        return relativePath(path);
+    }
+
+    return path;
+};
+
 const getHashedFile = (code: string) => {
     if (discoverFiles.has(code)) {
-        return discoverFiles.get(code);
+        return fixFilePath(discoverFiles.get(code)!);
     }
 
     const hashedFile = internalVendorPath(`discover-${md5(code)}.php`);
@@ -222,7 +265,7 @@ const getHashedFile = (code: string) => {
 
     discoverFiles.set(code, hashedFile);
 
-    return hashedFile;
+    return fixFilePath(hashedFile);
 };
 
 export const runPhp = (
@@ -233,13 +276,13 @@ export const runPhp = (
         code = "<?php\n\n" + code;
     }
 
-    const hashedFile = getHashedFile(code);
-
     const commandTemplate =
         config<string>("phpCommand", getDefaultPhpCommand()) ||
         getDefaultPhpCommand();
 
-    const command = `${commandTemplate} ${hashedFile}`;
+    const hashedFile = getHashedFile(code);
+
+    const command = `${commandTemplate} "${hashedFile}"`;
 
     const out = new Promise<string>(function (resolve, error) {
         cp.exec(

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -1,7 +1,8 @@
+import { getTemplate, TemplateName } from "@src/templates";
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as vscode from "vscode";
-import { getTemplate, TemplateName } from "../templates";
+import { config, PhpEnvironment } from "./config";
 import { error, info } from "./logger";
 import { showErrorPopup } from "./popup";
 import {


### PR DESCRIPTION
This PR adds a setting to specify your local PHP environment from several common scenarios. The default is to auto-detect the environment, as the extension currently does, but now you can specify your environment if need be.