### PR TITLE
Increase binary download timeout to 60s

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -78,6 +78,11 @@ const downloadBinary = async (context: vscode.ExtensionContext) => {
             vscode.Uri.parse(uri),
             filename,
             context,
+            undefined,
+            undefined,
+            {
+                timeoutInMs: 30_000,
+            },
         );
 
         if (osPlatform !== "win32") {

--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -81,7 +81,7 @@ const downloadBinary = async (context: vscode.ExtensionContext) => {
             undefined,
             undefined,
             {
-                timeoutInMs: 30_000,
+                timeoutInMs: 60_000,
             },
         );
 


### PR DESCRIPTION
Increases the timeout for downloading the binary to 60 seconds to account for varying internet connections.

Fixes #181 