### PR TITLE
Fix binary permissions cross platform

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -81,7 +81,7 @@ const downloadBinary = async (context: vscode.ExtensionContext) => {
         );
 
         if (osPlatform !== "win32") {
-            cp.execSync(`chmod +x ${file.fsPath.replace(" ", "\\ ")}`);
+            cp.execSync(`chmod +x "${file.fsPath}"`);
         }
 
         vscode.window.showInformationMessage(


### PR DESCRIPTION
Instead of escaping the path, just wrap it in quotes when running `chmod`.

Fixes #180