### PR TITLE
Allow configuration of project base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
                 "Laravel.basePath": {
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "_Relative_ base path for the Laravel project. This is used to resolve paths in the project. e.g. src, code/backend"
+                    "markdownDescription": "_Relative_ base path for the Laravel project. This is used to resolve paths in the project. e.g. src, code/backend\n\n_Requires extension reload after changing._"
                 },
                 "Laravel.showErrorPopups": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
                     "type": "string",
                     "description": "Template for running PHP code. Use {code} as a placeholder for the php file to run. e.g. `php \"{code}\"`"
                 },
+                "Laravel.basePath": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "_Relative_ base path for the Laravel project. This is used to resolve paths in the project. e.g. src, code/backend"
+                },
                 "Laravel.showErrorPopups": {
                     "type": "boolean",
                     "default": true,

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -3,6 +3,7 @@ import { GeneratedConfigKey } from "./generated-config";
 
 type ConfigKey =
     | GeneratedConfigKey
+    | "basePath"
     | "phpEnvironment"
     | "phpCommand"
     | "tests.docker.enabled"

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -211,8 +211,6 @@ export const runInLaravel = <T>(
 
     const command = template("bootstrapLaravel", {
         output: code,
-        vendor_autoload_path: projectPath("vendor/autoload.php", true),
-        bootstrap_path: projectPath("bootstrap/app.php", true),
     });
 
     return runPhp(command, description)

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
+import { config } from "./config";
 
 let internalVendorExists: boolean | null = null;
 
@@ -28,27 +29,16 @@ const trimFirstSlash = (srcPath: string): string => {
     return srcPath[0] === path.sep ? srcPath.substring(1) : srcPath;
 };
 
-export const projectPath = (srcPath = "", forCode = false): string => {
-    srcPath = srcPath.replace(/\//g, path.sep);
-    srcPath = trimFirstSlash(srcPath);
-
-    let basePath = "";
-    // let basePath = config<string>("basePath", "");
-
-    if (forCode === false && basePath.length > 0) {
-        return resolvePath(basePath, srcPath);
-    }
-
-    let basePathForCode = "";
-    // let basePathForCode = config<string>("basePathForCode", "");
-
-    if (forCode && basePathForCode.length > 0) {
-        return resolvePath(basePathForCode, srcPath);
-    }
+export const projectPath = (srcPath = ""): string => {
+    const basePath = config<string>("basePath", "");
 
     for (let workspaceFolder of getWorkspaceFolders()) {
-        if (fs.existsSync(path.join(workspaceFolder.uri.fsPath, "artisan"))) {
-            return path.join(workspaceFolder.uri.fsPath, srcPath);
+        if (
+            fs.existsSync(
+                path.join(workspaceFolder.uri.fsPath, basePath, "artisan"),
+            )
+        ) {
+            return path.join(workspaceFolder.uri.fsPath, basePath, srcPath);
         }
     }
 

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -29,16 +29,20 @@ const trimFirstSlash = (srcPath: string): string => {
     return srcPath[0] === path.sep ? srcPath.substring(1) : srcPath;
 };
 
+export const basePath = (srcPath = ""): string => {
+    return path.join(config<string>("basePath", ""), srcPath);
+};
+
 export const projectPath = (srcPath = ""): string => {
-    const basePath = config<string>("basePath", "");
+    srcPath = basePath(srcPath);
 
     for (let workspaceFolder of getWorkspaceFolders()) {
         if (
             fs.existsSync(
-                path.join(workspaceFolder.uri.fsPath, basePath, "artisan"),
+                path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
             )
         ) {
-            return path.join(workspaceFolder.uri.fsPath, basePath, srcPath);
+            return path.join(workspaceFolder.uri.fsPath, srcPath);
         }
     }
 
@@ -49,7 +53,10 @@ export const relativePath = (srcPath: string): string => {
     for (let workspaceFolder of getWorkspaceFolders()) {
         if (srcPath.startsWith(workspaceFolder.uri.fsPath)) {
             return trimFirstSlash(
-                srcPath.replace(workspaceFolder.uri.fsPath, ""),
+                srcPath.replace(
+                    path.join(workspaceFolder.uri.fsPath, basePath()),
+                    "",
+                ),
             );
         }
     }


### PR DESCRIPTION
This PR introduces the `basePath` config, allowing the user to configure the relative base path to their Laravel installation.

Fixes #46 