### PR TITLE
Fix for missing translation "path" property

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -107,12 +107,20 @@ $loader = app("translator")->getLoader();
 $namespaces = $loader->namespaces();
 
 $reflection = new ReflectionClass($loader);
-$property = $reflection->hasProperty("paths")
-  ? $reflection->getProperty("paths")
-  : $reflection->getProperty("path");
-$property->setAccessible(true);
+$property = null;
 
-$paths = \Illuminate\Support\Arr::wrap($property->getValue($loader));
+if ($reflection->hasProperty("paths")) {
+    $property = $reflection->getProperty("paths");
+} else if ($reflection->hasProperty("path")) {
+    $property = $reflection->getProperty("path");
+}
+
+if ($property !== null) {
+    $property->setAccessible(true);
+    $paths = \Illuminate\Support\Arr::wrap($property->getValue($loader));
+} else {
+    $paths = [];
+}
 
 $default = collect($paths)->flatMap(
   fn($path) => vscodeCollectTranslations($path)

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -107,12 +107,20 @@ $loader = app("translator")->getLoader();
 $namespaces = $loader->namespaces();
 
 $reflection = new ReflectionClass($loader);
-$property = $reflection->hasProperty("paths")
-  ? $reflection->getProperty("paths")
-  : $reflection->getProperty("path");
-$property->setAccessible(true);
+$property = null;
 
-$paths = \\Illuminate\\Support\\Arr::wrap($property->getValue($loader));
+if ($reflection->hasProperty("paths")) {
+    $property = $reflection->getProperty("paths");
+} else if ($reflection->hasProperty("path")) {
+    $property = $reflection->getProperty("path");
+}
+
+if ($property !== null) {
+    $property->setAccessible(true);
+    $paths = \\Illuminate\\Support\\Arr::wrap($property->getValue($loader));
+} else {
+    $paths = [];
+}
 
 $default = collect($paths)->flatMap(
   fn($path) => vscodeCollectTranslations($path)


### PR DESCRIPTION
Check for the `path` property instead of automatically trying to access it in case the translator is overridden.

Fixes #102 