### PR TITLE
Fix confusing "PHP Command" setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
                 },
                 "Laravel.phpCommand": {
                     "type": "string",
-                    "description": "Template for running PHP code. Use {code} as a placeholder for the php file to run. e.g. `php \"{code}\"`"
+                    "description": "Template for running PHP code. Use {code} as an optional placeholder for the php file to run. e.g. `php \"{code}\"`.\n\nIf no {code} is present, code filepath will be appended to the command."
                 },
                 "Laravel.basePath": {
                     "type": "string",

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -273,12 +273,13 @@ export const runPhp = (
     }
 
     const commandTemplate =
-        config<string>("phpCommand", getDefaultPhpCommand()) ||
-        getDefaultPhpCommand();
+        config<string>("phpCommand", "") || getDefaultPhpCommand();
 
     const hashedFile = getHashedFile(code);
 
-    const command = `${commandTemplate} "${hashedFile}"`;
+    const command = commandTemplate.includes("{code}")
+        ? commandTemplate.replace("{code}", hashedFile)
+        : `${commandTemplate} "${hashedFile}"`;
 
     const out = new Promise<string>(function (resolve, error) {
         cp.exec(


### PR DESCRIPTION
Addresses the (rightful) confusion around PHP Command:

- Actually allows for the replacing of `{code}` with the filepath if that is necessary for your command
- Automatically appends code filepath for command templates without `{code}`

Fixes #149 