### PR TITLE
Change debounce strategy

### DIFF
--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { getWorkspaceFolders, hasWorkspace } from "./project";
-import { debounce } from "./util";
+import { leadingDebounce } from "./util";
 
 type FileEvent = "change" | "create" | "delete";
 
@@ -22,17 +22,23 @@ export const loadAndWatch = (
 
     load();
 
+    const debounceTime = 1000;
+
     if (patterns instanceof Function) {
         patterns().then((result) => {
             if (result !== null) {
-                createFileWatcher(result, debounce(load, 750), events);
+                createFileWatcher(
+                    result,
+                    leadingDebounce(load, debounceTime),
+                    events,
+                );
             }
         });
 
         return;
     }
 
-    createFileWatcher(patterns, debounce(load, 750), events);
+    createFileWatcher(patterns, leadingDebounce(load, debounceTime), events);
 };
 
 export const createFileWatcher = (

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -73,3 +73,26 @@ export const debounce = <T extends (...args: any[]) => any>(
         }, wait);
     } as T;
 };
+
+export const leadingDebounce = <T extends (...args: any[]) => any>(
+    func: T,
+    wait: number,
+): T => {
+    let timeout: NodeJS.Timeout;
+    let lastInvocation = 0;
+
+    return function (this: any, ...args: any[]) {
+        clearTimeout(timeout);
+
+        if (lastInvocation < Date.now() - wait) {
+            // It's been a while since the last invocation, just call the function, no need to wait
+            func.apply(this, args);
+        } else {
+            timeout = setTimeout(() => {
+                func.apply(this, args);
+            }, wait);
+        }
+
+        lastInvocation = Date.now();
+    } as T;
+};


### PR DESCRIPTION
Changing from a strict `debounce` strategy to a `leadingDebounce` strategy, allowing us to respond more promptly when the system is not busy, but if it is, to back off and wait until it is not.