### PR TITLE
Translation fixes

### DIFF
--- a/php-templates/bootstrap-laravel.php
+++ b/php-templates/bootstrap-laravel.php
@@ -23,6 +23,10 @@ class VsCodeLaravel extends \Illuminate\Support\ServiceProvider
 
 function vsCodeToRelativePath($path)
 {
+    if (!str_contains($path, base_path())) {
+        return (string) $path;
+    }
+
     return ltrim(str_replace(base_path(), '', realpath($path)), DIRECTORY_SEPARATOR);
 }
 

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -1,93 +1,127 @@
 <?php
 
+function vsCodeGetJsonTranslationsFromFile($lang, $key, $value, $file, $lines)
+{
+    return [
+        "k" => $key,
+        "la" => $lang,
+        "vs" => collect(\Illuminate\Support\Arr::dot((\Illuminate\Support\Arr::wrap(__($key, [], $lang)))))
+            ->map(
+                fn($value, $k) => vsCodeTranslationValue(
+                    $key,
+                    $value,
+                    $file,
+                    $lines
+                )
+            )
+            ->filter()
+    ];
+}
+
 function vsCodeGetTranslationsFromFile($file, $path, $namespace)
 {
-  $key = pathinfo($file, PATHINFO_FILENAME);
+    $fileLines = \Illuminate\Support\Facades\File::lines($file);
+    $lines = [];
+    $inComment = false;
 
-  if ($namespace) {
-    $key = "{$namespace}::{$key}";
-  }
+    foreach ($fileLines as $index => $line) {
+        $trimmed = trim($line);
 
-  $lang = collect(explode(DIRECTORY_SEPARATOR, str_replace($path, "", $file)))
-    ->filter()
-    ->first();
+        if (substr($trimmed, 0, 2) === "/*") {
+            $inComment = true;
+            continue;
+        }
 
-  $fileLines = \Illuminate\Support\Facades\File::lines($file);
-  $lines = [];
-  $inComment = false;
+        if ($inComment) {
+            if (substr($trimmed, -2) !== "*/") {
+                continue;
+            }
 
-  foreach ($fileLines as $index => $line) {
-    $trimmed = trim($line);
+            $inComment = false;
+        }
 
-    if (substr($trimmed, 0, 2) === "/*") {
-      $inComment = true;
-      continue;
+        if (substr($trimmed, 0, 2) === "//") {
+            continue;
+        }
+
+        $lines[] = [$index + 1, $trimmed];
     }
 
-    if ($inComment) {
-      if (substr($trimmed, -2) !== "*/") {
-        continue;
-      }
+    if (pathinfo($file, PATHINFO_EXTENSION) === 'json') {
+        $lang = pathinfo($file, PATHINFO_FILENAME);
 
-      $inComment = false;
+        return collect(\Illuminate\Support\Facades\File::json($file))->map(
+            fn($value, $key) => vsCodeGetJsonTranslationsFromFile(
+                $lang,
+                $key,
+                $value,
+                vsCodeToRelativePath($file),
+                $lines,
+            ),
+        );
     }
 
-    if (substr($trimmed, 0, 2) === "//") {
-      continue;
+    $key = pathinfo($file, PATHINFO_FILENAME);
+
+    if ($namespace) {
+        $key = "{$namespace}::{$key}";
     }
 
-    $lines[] = [$index + 1, $trimmed];
-  }
+    $lang = collect(explode(DIRECTORY_SEPARATOR, str_replace($path, "", $file)))
+        ->filter()
+        ->slice(-2, 1)
+        ->first();
 
-  return [
-    "k" => $key,
-    "la" => $lang,
-    "vs" => collect(\Illuminate\Support\Arr::dot((\Illuminate\Support\Arr::wrap(__($key, [], $lang)))))
-      ->map(
-        fn($value, $key) => vsCodeTranslationValue(
-          $key,
-          $value,
-          str_replace(base_path(DIRECTORY_SEPARATOR), "", $file),
-          $lines
-        )
-      )
-      ->filter()
-  ];
+    return [
+        "k" => $key,
+        "la" => $lang,
+        "vs" => collect(\Illuminate\Support\Arr::dot((\Illuminate\Support\Arr::wrap(__($key, [], $lang)))))
+            ->map(
+                fn($value, $key) => vsCodeTranslationValue(
+                    $key,
+                    $value,
+                    vsCodeToRelativePath($file),
+                    $lines
+                )
+            )
+            ->filter()
+    ];
 }
 
 function vsCodeTranslationValue($key, $value, $file, $lines): ?array
 {
-  if (is_array($value)) {
-    return null;
-  }
+    $isJson = pathinfo($file, PATHINFO_EXTENSION) === 'json';
 
-  $lineNumber = 1;
-  $keys = explode(".", $key);
-  $index = 0;
-  $currentKey = array_shift($keys);
-
-  foreach ($lines as $index => $line) {
-    if (
-      strpos($line[1], '"' . $currentKey . '"', 0) !== false ||
-      strpos($line[1], "'" . $currentKey . "'", 0) !== false
-    ) {
-      $lineNumber = $line[0];
-      $currentKey = array_shift($keys);
+    if (is_array($value)) {
+        return null;
     }
 
-    if ($currentKey === null) {
-      break;
-    }
-  }
+    $lineNumber = 1;
+    $keys = $isJson ? [$key] : explode(".", $key);
+    $currentKey = array_shift($keys);
 
-  return [
-    "v" => $value,
-    "p" => $file,
-    "li" => $lineNumber,
-    "pa" => preg_match_all("/\:([A-Za-z0-9_]+)/", $value, $matches)
-      ? $matches[1]
-      : []
-  ];
+    foreach ($lines as $line) {
+        if (
+            strpos($line[1], '"' . $currentKey . '"', 0) !== false ||
+            strpos($line[1], "'" . $currentKey . "'", 0) !== false
+        ) {
+            $lineNumber = $line[0];
+            $currentKey = array_shift($keys);
+        }
+
+        if ($currentKey === null) {
+            break;
+        }
+    }
+
+    return [
+        "v" => $value,
+        "p" => $file,
+        "li" => $lineNumber,
+        "pa" => preg_match_all("/\:([A-Za-z0-9_]+)/", $value, $matches)
+            ? $matches[1]
+            : []
+    ];
 }
 
 function vscodeCollectTranslations(string $path, ?string $namespace = null)
@@ -102,6 +136,7 @@ function vscodeCollectTranslations(string $path, ?string $namespace = null)
         fn($file) => vsCodeGetTranslationsFromFile($file, $path, $namespace)
     );
 }
+
 
 $loader = app("translator")->getLoader();
 $namespaces = $loader->namespaces();
@@ -123,29 +158,38 @@ if ($property !== null) {
 }
 
 $default = collect($paths)->flatMap(
-  fn($path) => vscodeCollectTranslations($path)
+    fn($path) => vscodeCollectTranslations($path)
 );
 
 $namespaced = collect($namespaces)->flatMap(
-  fn($path, $namespace) => vscodeCollectTranslations($path, $namespace)
+    fn($path, $namespace) => vscodeCollectTranslations($path, $namespace)
 );
 
 $final = [];
 
 foreach ($default->merge($namespaced) as $value) {
-  foreach ($value["vs"] as $key => $v) {
-    $dotKey = "{$value["k"]}.{$key}";
+    if ($value instanceof \Illuminate\Support\Collection) {
+        foreach ($value as $val) {
+            foreach ($val["vs"] as $key => $v) {
+                $dotKey = $val["k"];
 
-    if (!isset($final[$dotKey])) {
-      $final[$dotKey] = [];
+                if (!isset($final[$dotKey])) {
+                    $final[$dotKey] = [];
+                }
+
+                $final[$dotKey][$val["la"]] = $v;
+            }
+        }
+    } else {
+        foreach ($value["vs"] as $key => $v) {
+            $dotKey = "{$value["k"]}.{$key}";
+            $final[$dotKey] ??= [];
+            $final[$dotKey][$value["la"]] ??= $v;
+        }
     }
-
-    $final[$dotKey][$value["la"]] = $v;
-
-    if ($value["la"] === \Illuminate\Support\Facades\App::currentLocale()) {
-      $final[$dotKey]["default"] = $v;
-    }
-  }
 }
 
-echo json_encode($final);
+echo json_encode([
+    'default' => \Illuminate\Support\Facades\App::currentLocale(),
+    'translations' => $final,
+]);

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -116,6 +116,7 @@ function vsCodeTranslationValue($key, $value, $file, $lines): ?array
 
     return [
         "v" => $value,
+        "f" => $currentKey === null,
         "p" => $file,
         "li" => $lineNumber,
         "pa" => preg_match_all("/\:([A-Za-z0-9_]+)/", $value, $matches)
@@ -177,6 +178,7 @@ foreach ($default->merge($namespaced) as $value) {
                     $final[$dotKey] = [];
                 }
 
+                $foundFullKey = \Illuminate\Support\Arr::pull($v, "f");
                 $final[$dotKey][$val["la"]] = $v;
             }
         }
@@ -184,7 +186,14 @@ foreach ($default->merge($namespaced) as $value) {
         foreach ($value["vs"] as $key => $v) {
             $dotKey = "{$value["k"]}.{$key}";
             $final[$dotKey] ??= [];
-            $final[$dotKey][$value["la"]] ??= $v;
+
+            $foundFullKey = \Illuminate\Support\Arr::pull($v, "f");
+
+            if ($foundFullKey) {
+              $final[$dotKey][$value["la"]] = $v;
+            } else {
+              $final[$dotKey][$value["la"]] ??= $v;
+            }
         }
     }
 }

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -36,7 +36,11 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
         doc,
         toFind,
         getTranslations,
-        ({ param }) => {
+        ({ param, index }) => {
+            if (index !== 0) {
+                return null;
+            }
+
             const translation =
                 getTranslations().items.translations[param.value];
 
@@ -92,7 +96,11 @@ export const diagnosticProvider = (
         doc,
         toFind,
         getTranslations,
-        ({ param }) => {
+        ({ param, index }) => {
+            if (index !== 0) {
+                return null;
+            }
+
             const item = getTranslations().items.translations[param.value];
 
             if (item) {

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -26,7 +26,9 @@ const toFind: FeatureTag = [
 ];
 
 const getDefault = (translation: TranslationItem) => {
-    return translation.default ?? translation[Object.keys(translation)[0]];
+    const langDefault = getTranslations().items.default;
+
+    return translation[langDefault] ?? translation[Object.keys(translation)[0]];
 };
 
 export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
@@ -35,7 +37,8 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
         toFind,
         getTranslations,
         ({ param }) => {
-            const translation = getTranslations().items[param.value];
+            const translation =
+                getTranslations().items.translations[param.value];
 
             if (!translation) {
                 return null;
@@ -58,7 +61,7 @@ export const hoverProvider: HoverProvider = (
     pos: vscode.Position,
 ): vscode.ProviderResult<vscode.Hover> => {
     return findHoverMatchesInDoc(doc, pos, toFind, getTranslations, (match) => {
-        const item = getTranslations().items[match];
+        const item = getTranslations().items.translations[match];
 
         if (!item) {
             return null;
@@ -90,7 +93,7 @@ export const diagnosticProvider = (
         toFind,
         getTranslations,
         ({ param }) => {
-            const item = getTranslations().items[param.value];
+            const item = getTranslations().items.translations[param.value];
 
             if (item) {
                 return null;
@@ -123,10 +126,10 @@ export const completionProvider = {
         }
 
         const totalTranslationItems = Object.entries(
-            getTranslations().items,
+            getTranslations().items.translations,
         ).length;
 
-        return Object.entries(getTranslations().items).map(
+        return Object.entries(getTranslations().items.translations).map(
             ([key, translations]) => {
                 let completionItem = new vscode.CompletionItem(
                     key,
@@ -163,7 +166,7 @@ export const completionProvider = {
         }
 
         // Parameters autocomplete
-        return Object.entries(getTranslations().items)
+        return Object.entries(getTranslations().items.translations)
             .filter(([key, value]) => key === result.param(0).value)
             .map(([key, value]) => {
                 return getDefault(value)

--- a/src/repositories/translations.ts
+++ b/src/repositories/translations.ts
@@ -12,16 +12,22 @@ export interface TranslationItem {
 }
 
 interface TranslationGroupResult {
-    [key: string]: TranslationItem;
+    default: string;
+    translations: {
+        [key: string]: TranslationItem;
+    };
 }
 
 interface TranslationGroupPhpResult {
-    [key: string]: {
+    default: string;
+    translations: {
         [key: string]: {
-            v: string;
-            p: string;
-            li: number;
-            pa: string[];
+            [key: string]: {
+                v: string;
+                p: string;
+                li: number;
+                pa: string[];
+            };
         };
     };
 }
@@ -31,26 +37,34 @@ const load = () => {
         template("translations"),
         "Translation namespaces",
     ).then((res) => {
-        const result: TranslationGroupResult = {};
+        const result: TranslationGroupResult["translations"] = {};
 
-        Object.entries(res).forEach(([namespace, translations]) => {
-            result[namespace] = {};
-            Object.entries(translations).forEach(([key, value]) => {
-                result[namespace][key] = {
-                    value: value.v,
-                    path: projectPath(value.p),
-                    line: value.li,
-                    params: value.pa,
-                };
-            });
-        });
+        Object.entries(res.translations).forEach(
+            ([namespace, translations]) => {
+                result[namespace] = {};
+                Object.entries(translations).forEach(([key, value]) => {
+                    result[namespace][key] = {
+                        value: value.v,
+                        path: projectPath(value.p),
+                        line: value.li,
+                        params: value.pa,
+                    };
+                });
+            },
+        );
 
-        return result;
+        return {
+            default: res.default,
+            translations: result,
+        };
     });
 };
 
 export const getTranslations = repository<TranslationGroupResult>(
     load,
     "{,**/}{lang,localization,localizations,trans,translation,translations}/{*,**/*}",
-    {},
+    {
+        default: "",
+        translations: {},
+    },
 );

--- a/src/templates/bootstrap-laravel.ts
+++ b/src/templates/bootstrap-laravel.ts
@@ -23,6 +23,10 @@ class VsCodeLaravel extends \\Illuminate\\Support\\ServiceProvider
 
 function vsCodeToRelativePath($path)
 {
+    if (!str_contains($path, base_path())) {
+        return (string) $path;
+    }
+
     return ltrim(str_replace(base_path(), '', realpath($path)), DIRECTORY_SEPARATOR);
 }
 

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -1,93 +1,127 @@
 // This file was generated from php-templates/translations.php, do not edit directly
 export default `
+function vsCodeGetJsonTranslationsFromFile($lang, $key, $value, $file, $lines)
+{
+    return [
+        "k" => $key,
+        "la" => $lang,
+        "vs" => collect(\\Illuminate\\Support\\Arr::dot((\\Illuminate\\Support\\Arr::wrap(__($key, [], $lang)))))
+            ->map(
+                fn($value, $k) => vsCodeTranslationValue(
+                    $key,
+                    $value,
+                    $file,
+                    $lines
+                )
+            )
+            ->filter()
+    ];
+}
+
 function vsCodeGetTranslationsFromFile($file, $path, $namespace)
 {
-  $key = pathinfo($file, PATHINFO_FILENAME);
+    $fileLines = \\Illuminate\\Support\\Facades\\File::lines($file);
+    $lines = [];
+    $inComment = false;
 
-  if ($namespace) {
-    $key = "{$namespace}::{$key}";
-  }
+    foreach ($fileLines as $index => $line) {
+        $trimmed = trim($line);
 
-  $lang = collect(explode(DIRECTORY_SEPARATOR, str_replace($path, "", $file)))
-    ->filter()
-    ->first();
+        if (substr($trimmed, 0, 2) === "/*") {
+            $inComment = true;
+            continue;
+        }
 
-  $fileLines = \\Illuminate\\Support\\Facades\\File::lines($file);
-  $lines = [];
-  $inComment = false;
+        if ($inComment) {
+            if (substr($trimmed, -2) !== "*/") {
+                continue;
+            }
 
-  foreach ($fileLines as $index => $line) {
-    $trimmed = trim($line);
+            $inComment = false;
+        }
 
-    if (substr($trimmed, 0, 2) === "/*") {
-      $inComment = true;
-      continue;
+        if (substr($trimmed, 0, 2) === "//") {
+            continue;
+        }
+
+        $lines[] = [$index + 1, $trimmed];
     }
 
-    if ($inComment) {
-      if (substr($trimmed, -2) !== "*/") {
-        continue;
-      }
+    if (pathinfo($file, PATHINFO_EXTENSION) === 'json') {
+        $lang = pathinfo($file, PATHINFO_FILENAME);
 
-      $inComment = false;
+        return collect(\\Illuminate\\Support\\Facades\\File::json($file))->map(
+            fn($value, $key) => vsCodeGetJsonTranslationsFromFile(
+                $lang,
+                $key,
+                $value,
+                vsCodeToRelativePath($file),
+                $lines,
+            ),
+        );
     }
 
-    if (substr($trimmed, 0, 2) === "//") {
-      continue;
+    $key = pathinfo($file, PATHINFO_FILENAME);
+
+    if ($namespace) {
+        $key = "{$namespace}::{$key}";
     }
 
-    $lines[] = [$index + 1, $trimmed];
-  }
+    $lang = collect(explode(DIRECTORY_SEPARATOR, str_replace($path, "", $file)))
+        ->filter()
+        ->slice(-2, 1)
+        ->first();
 
-  return [
-    "k" => $key,
-    "la" => $lang,
-    "vs" => collect(\\Illuminate\\Support\\Arr::dot((\\Illuminate\\Support\\Arr::wrap(__($key, [], $lang)))))
-      ->map(
-        fn($value, $key) => vsCodeTranslationValue(
-          $key,
-          $value,
-          str_replace(base_path(DIRECTORY_SEPARATOR), "", $file),
-          $lines
-        )
-      )
-      ->filter()
-  ];
+    return [
+        "k" => $key,
+        "la" => $lang,
+        "vs" => collect(\\Illuminate\\Support\\Arr::dot((\\Illuminate\\Support\\Arr::wrap(__($key, [], $lang)))))
+            ->map(
+                fn($value, $key) => vsCodeTranslationValue(
+                    $key,
+                    $value,
+                    vsCodeToRelativePath($file),
+                    $lines
+                )
+            )
+            ->filter()
+    ];
 }
 
 function vsCodeTranslationValue($key, $value, $file, $lines): ?array
 {
-  if (is_array($value)) {
-    return null;
-  }
+    $isJson = pathinfo($file, PATHINFO_EXTENSION) === 'json';
 
-  $lineNumber = 1;
-  $keys = explode(".", $key);
-  $index = 0;
-  $currentKey = array_shift($keys);
-
-  foreach ($lines as $index => $line) {
-    if (
-      strpos($line[1], '"' . $currentKey . '"', 0) !== false ||
-      strpos($line[1], "'" . $currentKey . "'", 0) !== false
-    ) {
-      $lineNumber = $line[0];
-      $currentKey = array_shift($keys);
+    if (is_array($value)) {
+        return null;
     }
 
-    if ($currentKey === null) {
-      break;
-    }
-  }
+    $lineNumber = 1;
+    $keys = $isJson ? [$key] : explode(".", $key);
+    $currentKey = array_shift($keys);
 
-  return [
-    "v" => $value,
-    "p" => $file,
-    "li" => $lineNumber,
-    "pa" => preg_match_all("/\\:([A-Za-z0-9_]+)/", $value, $matches)
-      ? $matches[1]
-      : []
-  ];
+    foreach ($lines as $line) {
+        if (
+            strpos($line[1], '"' . $currentKey . '"', 0) !== false ||
+            strpos($line[1], "'" . $currentKey . "'", 0) !== false
+        ) {
+            $lineNumber = $line[0];
+            $currentKey = array_shift($keys);
+        }
+
+        if ($currentKey === null) {
+            break;
+        }
+    }
+
+    return [
+        "v" => $value,
+        "p" => $file,
+        "li" => $lineNumber,
+        "pa" => preg_match_all("/\\:([A-Za-z0-9_]+)/", $value, $matches)
+            ? $matches[1]
+            : []
+    ];
 }
 
 function vscodeCollectTranslations(string $path, ?string $namespace = null)
@@ -102,6 +136,7 @@ function vscodeCollectTranslations(string $path, ?string $namespace = null)
         fn($file) => vsCodeGetTranslationsFromFile($file, $path, $namespace)
     );
 }
+
 
 $loader = app("translator")->getLoader();
 $namespaces = $loader->namespaces();
@@ -123,30 +158,39 @@ if ($property !== null) {
 }
 
 $default = collect($paths)->flatMap(
-  fn($path) => vscodeCollectTranslations($path)
+    fn($path) => vscodeCollectTranslations($path)
 );
 
 $namespaced = collect($namespaces)->flatMap(
-  fn($path, $namespace) => vscodeCollectTranslations($path, $namespace)
+    fn($path, $namespace) => vscodeCollectTranslations($path, $namespace)
 );
 
 $final = [];
 
 foreach ($default->merge($namespaced) as $value) {
-  foreach ($value["vs"] as $key => $v) {
-    $dotKey = "{$value["k"]}.{$key}";
+    if ($value instanceof \\Illuminate\\Support\\Collection) {
+        foreach ($value as $val) {
+            foreach ($val["vs"] as $key => $v) {
+                $dotKey = $val["k"];
 
-    if (!isset($final[$dotKey])) {
-      $final[$dotKey] = [];
+                if (!isset($final[$dotKey])) {
+                    $final[$dotKey] = [];
+                }
+
+                $final[$dotKey][$val["la"]] = $v;
+            }
+        }
+    } else {
+        foreach ($value["vs"] as $key => $v) {
+            $dotKey = "{$value["k"]}.{$key}";
+            $final[$dotKey] ??= [];
+            $final[$dotKey][$value["la"]] ??= $v;
+        }
     }
-
-    $final[$dotKey][$value["la"]] = $v;
-
-    if ($value["la"] === \\Illuminate\\Support\\Facades\\App::currentLocale()) {
-      $final[$dotKey]["default"] = $v;
-    }
-  }
 }
 
-echo json_encode($final);
+echo json_encode([
+    'default' => \\Illuminate\\Support\\Facades\\App::currentLocale(),
+    'translations' => $final,
+]);
 `;

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -116,6 +116,7 @@ function vsCodeTranslationValue($key, $value, $file, $lines): ?array
 
     return [
         "v" => $value,
+        "f" => $currentKey === null,
         "p" => $file,
         "li" => $lineNumber,
         "pa" => preg_match_all("/\\:([A-Za-z0-9_]+)/", $value, $matches)
@@ -177,6 +178,7 @@ foreach ($default->merge($namespaced) as $value) {
                     $final[$dotKey] = [];
                 }
 
+                $foundFullKey = \\Illuminate\\Support\\Arr::pull($v, "f");
                 $final[$dotKey][$val["la"]] = $v;
             }
         }
@@ -184,7 +186,14 @@ foreach ($default->merge($namespaced) as $value) {
         foreach ($value["vs"] as $key => $v) {
             $dotKey = "{$value["k"]}.{$key}";
             $final[$dotKey] ??= [];
-            $final[$dotKey][$value["la"]] ??= $v;
+
+            $foundFullKey = \\Illuminate\\Support\\Arr::pull($v, "f");
+
+            if ($foundFullKey) {
+              $final[$dotKey][$value["la"]] = $v;
+            } else {
+              $final[$dotKey][$value["la"]] ??= $v;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR addresses the following fixes:

- Translations from JSON files (fixes #192)
- Incorrect language identification from `vendor` lang files
- Reduce the size of the translations response by eliminating the duplicate `default` entry
- Fix for argument validation for anything but the first argument