### PR TITLE
App Bindings: Make sure reflected class is not null

### DIFF
--- a/php-templates/app.php
+++ b/php-templates/app.php
@@ -7,6 +7,10 @@ echo collect(app()->getBindings())
 
         $closureClass = $boundTo->getClosureScopeClass();
 
+        if ($closureClass === null) {
+            return [];
+        }
+
         return [
             $key => [
                 'path' => vsCodeToRelativePath($closureClass->getFileName()),

--- a/src/templates/app.ts
+++ b/src/templates/app.ts
@@ -7,6 +7,10 @@ echo collect(app()->getBindings())
 
         $closureClass = $boundTo->getClosureScopeClass();
 
+        if ($closureClass === null) {
+            return [];
+        }
+
         return [
             $key => [
                 'path' => vsCodeToRelativePath($closureClass->getFileName()),


### PR DESCRIPTION
On occasion the reflected scope class is `null`, this PR just adds a check and returns early if it is. 