### PR TITLE
Null logger for mini PHP scripts

### DIFF
--- a/php-templates/bootstrap-laravel.php
+++ b/php-templates/bootstrap-laravel.php
@@ -15,9 +15,13 @@ class VsCodeLaravel extends \Illuminate\Support\ServiceProvider
 
     public function boot()
     {
-        if (method_exists($this->app['log'], 'setHandlers')) {
-            $this->app['log']->setHandlers([new \Monolog\Handler\ProcessHandler()]);
-        }
+        config([
+            'logging.channels.null' => [
+                'driver' => 'monolog',
+                'handler' => \Monolog\Handler\NullHandler::class,
+            ],
+            'logging.default' => 'null',
+        ]);
     }
 }
 

--- a/src/templates/bootstrap-laravel.ts
+++ b/src/templates/bootstrap-laravel.ts
@@ -15,9 +15,13 @@ class VsCodeLaravel extends \\Illuminate\\Support\\ServiceProvider
 
     public function boot()
     {
-        if (method_exists($this->app['log'], 'setHandlers')) {
-            $this->app['log']->setHandlers([new \\Monolog\\Handler\\ProcessHandler()]);
-        }
+        config([
+            'logging.channels.null' => [
+                'driver' => 'monolog',
+                'handler' => \\Monolog\\Handler\\NullHandler::class,
+            ],
+            'logging.default' => 'null',
+        ]);
     }
 }
 


### PR DESCRIPTION
As the app runs in the background, explicitly set the `NullHandler` as the logger so that it doesn't log anything to the main application.

Should fix #190 