### PR TITLE
Added optional test func to PHP auto detection

### DIFF
--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -85,12 +85,17 @@ const getPhpCommand = (): string => {
 
     const options = new Map<
         PhpEnvironment,
-        { check: string | string[]; command: string }
+        {
+            check: string | string[];
+            command: string;
+            test?: (output: string) => boolean;
+        }
     >();
 
     options.set("herd", {
         check: "herd which-php",
         command: `"{binaryPath}"`,
+        test: (output) => !output.includes("No usable PHP version found"),
     });
 
     options.set("valet", {
@@ -134,7 +139,7 @@ const getPhpCommand = (): string => {
                 check = checks.shift();
             }
 
-            if (result !== "") {
+            if (result !== "" && (!option.test || option.test(result))) {
                 info(`Using ${key} PHP installation: ${result}`);
 
                 phpEnvKey = key;


### PR DESCRIPTION
The PHP auto detector now includes an optional `test` method to do a final check and make sure the output is valid before selecting the PHP installation.