### PR TITLE
Fix invalid translation files crashing the extension.

### DIFF
--- a/generate-templates.php
+++ b/generate-templates.php
@@ -6,7 +6,7 @@ foreach ($templates as $template) {
     $content = file_get_contents($template);
 
     $content = str_replace('\\', '\\\\', $content);
-    $content = str_replace('<?php', '', $content);
+    $content = substr_replace($content, '', strpos($content,'<?php'), strlen('<?php'));
     $content = implode("\n", [
         "// This file was generated from {$template}, do not edit directly",
         'export default `',

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -238,6 +238,5 @@ foreach ($default->merge($namespaced) as $value) {
 
 echo json_encode([
     'default' => \Illuminate\Support\Facades\App::currentLocale(),
-    'translations' => $final,
-    'error'=> null
+    'translations' => $final
 ]);

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -24,7 +24,7 @@ function validateFile($file){
             if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
                 throw new Exception('Invalid JSON');
             }
-        }catch(Exception $e){
+        }catch(Throwable $e){
             echo 'Translation Files: Invalid JSON translation file at: '.$file;
             exit(0);
         }
@@ -33,11 +33,6 @@ function validateFile($file){
     if (pathinfo($file, PATHINFO_EXTENSION) === 'php'){
         try{
             $content = file_get_contents($file);
-            $parseResult =shell_exec('php -l '.$file);
-           
-            if(str_contains($parseResult,'No syntax errors detected') === false){
-                throw new Exception('Parse Error');
-            }
             if(str_contains($content,'<?php') === false){
                 throw new Exception('<?php not included');
             }
@@ -45,12 +40,13 @@ function validateFile($file){
             $content = str_replace('<?php','',$content);
             $content =  str_replace('?>','',$content);
 
-            eval($content);
-
-        }catch(Exception $e){
-    
-            echo 'Translation Files: Invalid PHP translation file at: '.$file;
+            $result = eval($content);
+            if(is_array($result) === false){
+                throw new Exception('return type is not an array');
+            }
             
+        }catch(Throwable $e){
+            echo 'Translation Files: Invalid PHP translation file at: '.$file;
             exit(0);
         }
     }

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -230,7 +230,14 @@ export const runInLaravel = <T>(
 
             throw new Error(result);
         })
-        .catch((e) => {
+        .catch((e) => { 
+            if(e.toString().includes('Translation Files: Invalid')){
+                error(e.toString().replace(toTemplateVar("start_output"),''));
+                return {
+                    default:"",
+                    translations:{}
+                };
+            }
             if (e.toString().includes("ParseError")) {
                 // If we it's a parse error let's not show the popup,
                 // probably just a momentary syntax error

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -24,7 +24,7 @@ function validateFile($file){
             if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
                 throw new Exception('Invalid JSON');
             }
-        }catch(Exception $e){
+        }catch(Throwable $e){
             echo 'Translation Files: Invalid JSON translation file at: '.$file;
             exit(0);
         }
@@ -33,11 +33,6 @@ function validateFile($file){
     if (pathinfo($file, PATHINFO_EXTENSION) === 'php'){
         try{
             $content = file_get_contents($file);
-            $parseResult =shell_exec('php -l '.$file);
-           
-            if(str_contains($parseResult,'No syntax errors detected') === false){
-                throw new Exception('Parse Error');
-            }
             if(str_contains($content,'<?php') === false){
                 throw new Exception('<?php not included');
             }
@@ -45,12 +40,12 @@ function validateFile($file){
             $content = str_replace('<?php','',$content);
             $content =  str_replace('?>','',$content);
 
-            eval($content);
-
-        }catch(Exception $e){
-    
+            $result = eval($content);
+            if(is_array($result) === false){
+                throw new Exception('return type is not an array');
+            }
+        }catch(Throwable $e){
             echo 'Translation Files: Invalid PHP translation file at: '.$file;
-            
             exit(0);
         }
     }

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -238,7 +238,6 @@ foreach ($default->merge($namespaced) as $value) {
 
 echo json_encode([
     'default' => \\Illuminate\\Support\\Facades\\App::currentLocale(),
-    'translations' => $final,
-    'error'=> null
+    'translations' => $final
 ]);
 `;

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -17,9 +17,47 @@ function vsCodeGetJsonTranslationsFromFile($lang, $key, $value, $file, $lines)
             ->filter()
     ];
 }
+function validateFile($file){
+    if (pathinfo($file, PATHINFO_EXTENSION) === 'json'){ 
+        try{
+           $decoded = json_decode(file_get_contents($file)); 
+            if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
+                throw new Exception('Invalid JSON');
+            }
+        }catch(Exception $e){
+            echo 'Translation Files: Invalid JSON translation file at: '.$file;
+            exit(0);
+        }
+     
+    }
+    if (pathinfo($file, PATHINFO_EXTENSION) === 'php'){
+        try{
+            $content = file_get_contents($file);
+            $parseResult =shell_exec('php -l '.$file);
+           
+            if(str_contains($parseResult,'No syntax errors detected') === false){
+                throw new Exception('Parse Error');
+            }
+            if(str_contains($content,'<?php') === false){
+                throw new Exception('<?php not included');
+            }
+            
+            $content = str_replace('<?php','',$content);
+            $content =  str_replace('?>','',$content);
 
+            eval($content);
+
+        }catch(Exception $e){
+    
+            echo 'Translation Files: Invalid PHP translation file at: '.$file;
+            
+            exit(0);
+        }
+    }
+}
 function vsCodeGetTranslationsFromFile($file, $path, $namespace)
 {
+    validateFile($file);
     $fileLines = \\Illuminate\\Support\\Facades\\File::lines($file);
     $lines = [];
     $inComment = false;
@@ -201,5 +239,6 @@ foreach ($default->merge($namespaced) as $value) {
 echo json_encode([
     'default' => \\Illuminate\\Support\\Facades\\App::currentLocale(),
     'translations' => $final,
+    'error'=> null
 ]);
 `;


### PR DESCRIPTION
This PR prevents extension from crashing when the user is working on translation files.

Fixes the following scenarios:
1. Creating an new php/json translation file
2. Invalid JSON structure
3. Syntax and runtime errors/exception in the PHP translation files

EDIT: I think this should fix #212 