### PR TITLE
Add Lando compatibility for the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
                         "herd",
                         "valet",
                         "sail",
+                        "lando",
                         "local"
                     ],
                     "enumItemLabels": [
@@ -84,6 +85,7 @@
                         "Herd",
                         "Valet",
                         "Sail",
+                        "Lando",
                         "Local"
                     ],
                     "markdownEnumDescriptions": [
@@ -91,6 +93,7 @@
                         "Auto detect PHP version Herd is using for the project.",
                         "Auto detect PHP version Valet is using for the project.",
                         "Sail",
+                        "Lando",
                         "Use PHP installed on the local machine."
                     ],
                     "default": "auto",

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -21,4 +21,10 @@ export const configAffected = (
     ...keys: ConfigKey[]
 ): boolean => keys.some((key) => event.affectsConfiguration(configKey(key)));
 
-export type PhpEnvironment = "auto" | "herd" | "valet" | "sail" | "local";
+export type PhpEnvironment =
+    | "auto"
+    | "herd"
+    | "valet"
+    | "sail"
+    | "local"
+    | "lando";

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -28,7 +28,7 @@ let hasVendor = projectPathExists("vendor/autoload.php");
 const hasBootstrap = projectPathExists("bootstrap/app.php");
 
 let phpEnvKey: PhpEnvironment | null = null;
-const phpEnvsThatUseRelativePaths: PhpEnvironment[] = ["sail"];
+const phpEnvsThatUseRelativePaths: PhpEnvironment[] = ["sail", "lando"];
 
 export const initVendorWatchers = () => {
     // fs.readdirSync(internalVendorPath()).forEach((file) => {
@@ -115,6 +115,11 @@ const getPhpCommand = (): string => {
     options.set("sail", {
         check: "./vendor/bin/sail ps",
         command: "./vendor/bin/sail php",
+    });
+
+    options.set("lando", {
+        check: "lando info",
+        command: "lando ssh -c 'php {code}'",
     });
 
     for (const [key, option] of options.entries()) {

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -113,8 +113,8 @@ const getPhpCommand = (): string => {
     });
 
     options.set("lando", {
-        check: "lando info",
-        command: "lando ssh -c 'php {code}'",
+        check: "lando exec appserver -- php -r 'echo PHP_BINARY;'",
+        command: "lando exec appserver -- php",
     });
 
     options.set("local", {

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -113,8 +113,8 @@ const getPhpCommand = (): string => {
     });
 
     options.set("lando", {
-        check: "lando exec appserver -- php -r 'echo PHP_BINARY;'",
-        command: "lando exec appserver -- php",
+        check: "lando php -r 'echo PHP_BINARY;'",
+        command: "lando php",
     });
 
     options.set("local", {

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -107,11 +107,6 @@ const getPhpCommand = (): string => {
         command: `"{binaryPath}"`,
     });
 
-    options.set("local", {
-        check: "php -r 'echo PHP_BINARY;'",
-        command: `"{binaryPath}"`,
-    });
-
     options.set("sail", {
         check: "./vendor/bin/sail ps",
         command: "./vendor/bin/sail php",
@@ -120,6 +115,11 @@ const getPhpCommand = (): string => {
     options.set("lando", {
         check: "lando info",
         command: "lando ssh -c 'php {code}'",
+    });
+
+    options.set("local", {
+        check: "php -r 'echo PHP_BINARY;'",
+        command: `"{binaryPath}"`,
     });
 
     for (const [key, option] of options.entries()) {


### PR DESCRIPTION
[Lando](https://lando.dev/) is a local development tool that streamlines working with Docker-based environments, making it easy to set up and manage development environments for web apps.

Currently, this extension is not compatible with Lando.

This PR resolves that issue, enabling support for Lando.