### PR TITLE
Improvements to Eloquent docblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Laravel extension will be documented in this file.
 
 ## [Unreleased]
 
-- Nothing yet
+- Improved Gate/Policy support ([#254](https://github.com/laravel/vs-code-extension/pull/254))
 
 ## [0.1.19]
 

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -199,10 +199,10 @@ const getAttributeBlocks = (
 };
 
 const getAttributeType = (attr: Eloquent.Attribute): string => {
-    const type = getActualType(attr.cast || attr.type);
+    const type = getActualType(attr.cast, attr.type);
 
     if (attr.nullable && type !== "mixed") {
-        return `${type}|null`
+        return `${type}|null`;
     }
     
     return type;

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -302,7 +302,7 @@ const findInMapping = (
 };
 
 const getActualType = (cast: string | null, type: string): string => {
-    const finalType = findInMapping(castMapping, cast) ?? findInMapping(typeMapping, type) ?? "mixed";
+    const finalType = findInMapping(castMapping, cast) || cast || findInMapping(typeMapping, type) || "mixed";
 
     if (finalType.includes("\\") && !finalType.startsWith("\\")) {
         return `\\${finalType}`;

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -264,6 +264,7 @@ const typeMapping: Record<string, (string | RegExp)[]> = {
         "path",
         "time",
         "uuid",
+        "year",
         "point",
         "circle",
         "polygon",

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -201,7 +201,11 @@ const getAttributeBlocks = (
 const getAttributeType = (attr: Eloquent.Attribute): string => {
     const type = getActualType(attr.cast || attr.type);
 
-    return attr.nullable ? `${type}|null` : type;
+    if (attr.nullable && type !== "mixed") {
+        return `${type}|null`
+    }
+    
+    return type;
 };
 
 const mapType = (type: string): string => {

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -204,57 +204,32 @@ const getAttributeType = (attr: Eloquent.Attribute): string => {
     if (attr.nullable && type !== "mixed") {
         return `${type}|null`;
     }
-    
+
     return type;
 };
 
-const castMapping: Record<string, (string | RegExp)[]> = {
-    array: [
-        "json",
-        "encrypted:json",
-        "encrypted:array",
-    ],
-    int: [
-        "timestamp",
-    ],
-    mixed: [
-        "attribute",
-        "accessor",
-        "encrypted",
-    ],
-    object: [
-        "encrypted:object",
-    ],
-    string: [
-        "hashed",
-    ],
-    "\\Illuminate\\Support\\Carbon": [
-        "date",
-        "datetime",
-    ],
-    "\\Illuminate\\Support\\Collection": [
-        "encrypted:collection",
-    ],
+type TypeMapping = Record<string, (string | RegExp)[]>;
+
+const castMapping: TypeMapping = {
+    array: ["json", "encrypted:json", "encrypted:array"],
+    int: ["timestamp"],
+    mixed: ["attribute", "accessor", "encrypted"],
+    object: ["encrypted:object"],
+    string: ["hashed"],
+    "\\Illuminate\\Support\\Carbon": ["date", "datetime"],
+    "\\Illuminate\\Support\\Collection": ["encrypted:collection"],
 };
 
-const typeMapping: Record<string, (string | RegExp)[]> = {
-    bool: [
-        /^boolean(\((0|1)\))?$/,
-        /^tinyint( unsigned)?(\(\d+\))?$/,
-    ],
+const typeMapping: TypeMapping = {
+    bool: [/^boolean(\((0|1)\))?$/, /^tinyint( unsigned)?(\(\d+\))?$/],
     float: [
         "real",
         "money",
         "double precision",
         /^(double|decimal|numeric)(\(\d+\,\d+\))?$/,
     ],
-    int: [
-        /^(big)?serial$/,
-        /^(small|big)?int(eger)?( unsigned)?$/,
-    ],
-    resource: [
-        "bytea",
-    ],
+    int: [/^(big)?serial$/, /^(small|big)?int(eger)?( unsigned)?$/],
+    resource: ["bytea"],
     string: [
         "box",
         "cidr",
@@ -279,8 +254,8 @@ const typeMapping: Record<string, (string | RegExp)[]> = {
 };
 
 const findInMapping = (
-    mapping: Record<string, (string | RegExp)[]>,
-    value: string | null
+    mapping: TypeMapping,
+    value: string | null,
 ): string | null => {
     if (value === null) {
         return null;
@@ -302,7 +277,11 @@ const findInMapping = (
 };
 
 const getActualType = (cast: string | null, type: string): string => {
-    const finalType = findInMapping(castMapping, cast) || cast || findInMapping(typeMapping, type) || "mixed";
+    const finalType =
+        findInMapping(castMapping, cast) ||
+        cast ||
+        findInMapping(typeMapping, type) ||
+        "mixed";
 
     if (finalType.includes("\\") && !finalType.startsWith("\\")) {
         return `\\${finalType}`;

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -258,7 +258,6 @@ const typeMapping: Record<string, (string | RegExp)[]> = {
     string: [
         "box",
         "cidr",
-        "date",
         "inet",
         "line",
         "lseg",
@@ -270,6 +269,7 @@ const typeMapping: Record<string, (string | RegExp)[]> = {
         "polygon",
         "interval",
         /^json(b)?$/,
+        /^date(time)?$/,
         /^macaddr(8)?$/,
         /^(long|medium)?text$/,
         /^(var)?char(acter)?( varying)??(\(\d+\))?$/,


### PR DESCRIPTION
Hi Joe (and/or other maintainers)!

Love the hard work y'all are doing with this extension.

Personally, I use the Eloquent attribute autocompletion feature a lot, and I've been hacking on the extension to make it match the database schema better.

I like the type mapping refactor done in https://github.com/laravel/vs-code-extension/pull/233, but I hope I can offer a few suggestions to make it even more robust:

## 1. Separate cast mapping from raw type mapping
Currently, the extension maps the `attribute.cast` (from the Eloquent model) in the same way as the raw `attribute.type` (from the database). But this often produces docblock types that do not match the actual PHP type.

For instance, an attribute that is _cast_ to `"datetime"` has the `\\Illuminate\\Support\\Carbon` PHP type, but a MySQL table column with the raw type `"datetime"` is still just a `string` in PHP. 

So given the following `model:show` output:

<img width="361" alt="image" src="https://github.com/user-attachments/assets/54d1601b-2093-4aba-83ef-2d2101790a7e" />

The extension in its current form, generates the following docblock:

<img width="436" alt="image" src="https://github.com/user-attachments/assets/6f6dc3c5-9eb3-4744-b955-3b32fcaabefe" />

But if you dump the record, it shows the actual PHP types, which are:

<img width="427" alt="image" src="https://github.com/user-attachments/assets/ed5b8d6e-30db-447d-a6e1-3ea572826fdf" />

To solve this, I have split the list into mappings for casts and mappings for raw database types. If we fail to find a mapping for the cast, we try to map the type. This generates the following docblocks:

<img width="432" alt="image" src="https://github.com/user-attachments/assets/306dc92b-fe84-419c-a0cd-5b934d03883d" />

## 2. Increased the amount of supported database types

I'm sure we're not there yet, but I've gone through I think all the PostgreSQL column types and I've started on the MySQL ones.

I've used a lot more regular expressions, to group similar types, but I'm happy to break that up into a few more simple regex's if you want.

## 3. Return "mixed" if we don't find a mapping

Originally, when the extension failed to find a mapping, it would return the original type. This worked fine when dealing with custom casts, but not if there was no cast to begin with. The extension would then return the original raw database type as a final type. This would result in an invalid PHP type in the docblock.

Returning `"mixed"` instead means we should never generate invalid docblocks anymore.

## 4. Don't return "mixed|null"

Since `mixed` is a standalone type, I prevent the final type from becoming `mixed|null`, because that is not a valid type.