### PR TITLE
Add missing namespace to Gate in auth template

### DIFF
--- a/php-templates/auth.php
+++ b/php-templates/auth.php
@@ -9,7 +9,7 @@ $modelPolicies = collect(get_declared_classes())
         \Illuminate\Foundation\Auth\User::class,
     ]))
     ->flatMap(fn($class) => [
-        $class => Gate::getPolicyFor($class),
+        $class => \Illuminate\Support\Facades\Gate::getPolicyFor($class),
     ])
     ->filter(fn($policy) => $policy !== null);
 

--- a/src/templates/auth.ts
+++ b/src/templates/auth.ts
@@ -9,7 +9,7 @@ $modelPolicies = collect(get_declared_classes())
         \\Illuminate\\Foundation\\Auth\\User::class,
     ]))
     ->flatMap(fn($class) => [
-        $class => Gate::getPolicyFor($class),
+        $class => \\Illuminate\\Support\\Facades\\Gate::getPolicyFor($class),
     ])
     ->filter(fn($policy) => $policy !== null);
 


### PR DESCRIPTION
Running the latest build (0.1.20) I got an "Auth Data" error: `Class "Gate" not found"`

Full extension error output was as follows:
```
Error: __VSCODE_LARAVEL_START_OUTPUT__
   Error 

  Class "Gate" not found

  at vendor/_laravel_ide/discover-1a355f6d894b35ff22ab04d09ffd8e42.php:51
     47▕         \Illuminate\Database\Eloquent\Relations\Pivot::class,
     48▕         \Illuminate\Foundation\Auth\User::class,
     49▕     ]))
     50▕     ->flatMap(fn($class) => [
  ➜  51▕         $class => Gate::getPolicyFor($class),
     52▕     ])
     53▕     ->filter(fn($policy) => $policy !== null);
     54▕ 
     55▕ function vsCodeGetPolicyInfo($policy, $model)
```

This PR updates the template with the full namespace so this error does not occur anymore.