### PR TITLE
Reduce error popups

### DIFF
--- a/php-templates/bootstrap-laravel.php
+++ b/php-templates/bootstrap-laravel.php
@@ -5,7 +5,35 @@ error_reporting(E_ERROR | E_PARSE);
 define('LARAVEL_START', microtime(true));
 
 require_once __DIR__ . '/../autoload.php';
-$app = require_once __DIR__ . '/../../bootstrap/app.php';
+
+class LaravelVsCode
+{
+    public static function relativePath($path)
+    {
+        if (!str_contains($path, base_path())) {
+            return (string) $path;
+        }
+
+        return ltrim(str_replace(base_path(), '', realpath($path)), DIRECTORY_SEPARATOR);
+    }
+
+    public static function outputMarker($key)
+    {
+        return '__VSCODE_LARAVEL_' . $key . '__';
+    }
+
+    public static function startupError(\Throwable $e)
+    {
+        throw new Error(self::outputMarker('STARTUP_ERROR') . ': ' . $e->getMessage());
+    }
+}
+
+try {
+    $app = require_once __DIR__ . '/../../bootstrap/app.php';
+} catch (\Throwable $e) {
+    LaravelVsCode::startupError($e);
+    exit(1);
+}
 
 $app->register(new class($app) extends \Illuminate\Support\ServiceProvider
 {
@@ -21,23 +49,16 @@ $app->register(new class($app) extends \Illuminate\Support\ServiceProvider
     }
 });
 
-class LaravelVsCode
-{
-    public static function relativePath($path)
-    {
-        if (!str_contains($path, base_path())) {
-            return (string) $path;
-        }
-
-        return ltrim(str_replace(base_path(), '', realpath($path)), DIRECTORY_SEPARATOR);
-    }
+try {
+    $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+    $kernel->bootstrap();
+} catch (\Throwable $e) {
+    LaravelVsCode::startupError($e);
+    exit(1);
 }
 
-$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
-$kernel->bootstrap();
-
-echo '__VSCODE_LARAVEL_START_OUTPUT__';
+echo LaravelVsCode::outputMarker('START_OUTPUT');
 __VSCODE_LARAVEL_OUTPUT__;
-echo '__VSCODE_LARAVEL_END_OUTPUT__';
+echo LaravelVsCode::outputMarker('END_OUTPUT');
 
 exit(0);

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -100,8 +100,18 @@ $translator = new class
     protected function linesFromJsonFile($file)
     {
         $contents = file_get_contents($file);
+
+        try {
+            $json = json_decode($contents, true) ?? [];
+        } catch (Exception $e) {
+            return [[], []];
+        }
+
+        if (count($json) === 0) {
+            return [[], []];
+        }
+
         $lines = explode(PHP_EOL, $contents);
-        $json = json_decode($contents, true);
         $encoded = array_map(
             fn($k) => [json_encode($k), $k],
             array_keys($json),

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -103,7 +103,7 @@ $translator = new class
 
         try {
             $json = json_decode($contents, true) ?? [];
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             return [[], []];
         }
 
@@ -120,7 +120,7 @@ $translator = new class
         $searchRange = 2;
 
         foreach ($encoded as $index => $keys) {
-            // Pretty likely the be on the line that is the index, go happy path first
+            // Pretty likely to be on the line that is the index, go happy path first
             if (strpos($lines[$index + 1] ?? '', $keys[0]) !== false) {
                 $result[$keys[1]] = $index + 2;
                 continue;

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -242,8 +242,11 @@ export const runInLaravel = <T>(
             throw new Error(result);
         })
         .catch((e) => {
-            if (e.toString().includes("ParseError")) {
-                // If we it's a parse error let's not show the popup,
+            if (
+                e.toString().includes("ParseError") ||
+                e.toString().includes(toTemplateVar("STARTUP_ERROR"))
+            ) {
+                // If we it's a parse error or an app-wide error let's not show the popup,
                 // probably just a momentary syntax error
                 error(e);
                 return;

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -103,7 +103,7 @@ $translator = new class
 
         try {
             $json = json_decode($contents, true) ?? [];
-        } catch (Exception $e) {
+        } catch (\\Throwable $e) {
             return [[], []];
         }
 
@@ -120,7 +120,7 @@ $translator = new class
         $searchRange = 2;
 
         foreach ($encoded as $index => $keys) {
-            // Pretty likely the be on the line that is the index, go happy path first
+            // Pretty likely to be on the line that is the index, go happy path first
             if (strpos($lines[$index + 1] ?? '', $keys[0]) !== false) {
                 $result[$keys[1]] = $index + 2;
                 continue;

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -100,8 +100,18 @@ $translator = new class
     protected function linesFromJsonFile($file)
     {
         $contents = file_get_contents($file);
+
+        try {
+            $json = json_decode($contents, true) ?? [];
+        } catch (Exception $e) {
+            return [[], []];
+        }
+
+        if (count($json) === 0) {
+            return [[], []];
+        }
+
         $lines = explode(PHP_EOL, $contents);
-        $json = json_decode($contents, true);
         $encoded = array_map(
             fn($k) => [json_encode($k), $k],
             array_keys($json),


### PR DESCRIPTION
When there's an app-wide error or a syntax error within the app, we don't need to show an error popup. 

Popup errors should be restricted to errors within the repo scripts themselves or parser CLI errors.