### PR TITLE
Enable Eloquent Model property auto-complete after sole, find, first, or firstOrFail

### DIFF
--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -80,7 +80,7 @@ const getBuilderReturnType = (
         return `\\Illuminate\\Database\\Eloquent\\Builder<${className}>`;
     }
 
-    const certainOfType = ["sole", "first", "firstOrFail"].includes(method.name);
+    const certainOfType = ["sole", "find", "first", "firstOrFail"].includes(method.name);
 
     const returnType = method.return
         .replace(

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -202,7 +202,7 @@ const getAttributeBlocks = (
 
     if (!["accessor", "attribute"].includes(attr.cast || "")) {
         blocks.push(
-            `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}> where${attr.title_case}($value)`,
+            `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className} where${attr.title_case}($value)`,
         );
     }
 

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -77,7 +77,7 @@ const getBuilderReturnType = (
     }
 
     if (["static", "self"].includes(method.return)) {
-        return `\\Illuminate\\Database\\Eloquent\\Builder<${className}>`;
+        return `\\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}`;
     }
 
     const certainOfType = ["sole", "find", "first", "firstOrFail"].includes(method.name);
@@ -85,7 +85,7 @@ const getBuilderReturnType = (
     const returnType = method.return
         .replace(
             "$this",
-            `\\Illuminate\\Database\\Eloquent\\Builder<${className}>`,
+            `\\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}`,
         )
         .replace("\\TReturn", "mixed")
         .replace("TReturn", "mixed")
@@ -202,7 +202,7 @@ const getAttributeBlocks = (
 
     if (!["accessor", "attribute"].includes(attr.cast || "")) {
         blocks.push(
-            `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}> where${attr.title_case}($value)`,
+            `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}> where${attr.title_case}($value)`,
         );
     }
 

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -9,8 +9,9 @@ interface ClassBlock {
     blocks: string[];
 }
 
-// TODO: Chunk into several files if we have a lot of models?
-// TODO: Check if doc block is already in model file, skip if it is
+const modelBuilderType = (className: string) =>
+    `\\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}`;
+
 export const writeEloquentDocBlocks = (
     models: Eloquent.Models,
     builderMethods: Eloquent.BuilderMethod[],
@@ -77,25 +78,27 @@ const getBuilderReturnType = (
     }
 
     if (["static", "self"].includes(method.return)) {
-        return `\\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}`;
+        return modelBuilderType(className);
     }
 
-    const certainOfType = ["sole", "find", "first", "firstOrFail"].includes(method.name);
+    const returnsSingleModel = [
+        "sole",
+        "find",
+        "first",
+        "firstOrFail",
+    ].includes(method.name);
 
     const returnType = method.return
-        .replace(
-            "$this",
-            `\\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className}`,
-        )
+        .replace("$this", modelBuilderType(className))
         .replace("\\TReturn", "mixed")
         .replace("TReturn", "mixed")
-        .replace("\\TValue", certainOfType ? className : "mixed")
-        .replace("TValue", certainOfType ? className : "mixed")
-        .replace("object", certainOfType ? className : "mixed");
-    
+        .replace("\\TValue", returnsSingleModel ? className : "mixed")
+        .replace("TValue", returnsSingleModel ? className : "mixed")
+        .replace("object", returnsSingleModel ? className : "mixed");
+
     if (returnType.includes("mixed")) {
         return "mixed";
-    };
+    }
 
     return returnType;
 };
@@ -110,7 +113,7 @@ const getBlocks = (
         .concat(
             [...model.scopes, "newModelQuery", "newQuery", "query"].map(
                 (method) => {
-                    return `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className} ${method}()`;
+                    return `@method static ${modelBuilderType(className)} ${method}()`;
                 },
             ),
         )
@@ -202,7 +205,7 @@ const getAttributeBlocks = (
 
     if (!["accessor", "attribute"].includes(attr.cast || "")) {
         blocks.push(
-            `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className} where${attr.title_case}($value)`,
+            `@method static ${modelBuilderType(className)} where${attr.title_case}($value)`,
         );
     }
 

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -68,23 +68,25 @@ const getBuilderReturnType = (
         return "mixed";
     }
 
-    const returnType = method.return
-        .replace(
-            "$this",
-            `\\Illuminate\\Database\\Eloquent\\Builder|${className}`,
-        )
-        .replace("\\TReturn", "mixed")
-        .replace("TReturn", "mixed")
-        .replace("\\TValue", "mixed")
-        .replace("TValue", "mixed");
-
-    if (["static", "self"].includes(method.return)) {
-        return `\\Illuminate\\Database\\Eloquent\\Builder|${className}`;
-    }
-
     if (method.return === "never") {
         return "void";
     }
+
+    if (["static", "self"].includes(method.return)) {
+        return `\\Illuminate\\Database\\Eloquent\\Builder<${className}>`;
+    }
+
+    const certainOfType = ["sole", "first", "firstOrFail"].includes(method.name);
+
+    const returnType = method.return
+        .replace(
+            "$this",
+            `\\Illuminate\\Database\\Eloquent\\Builder<${className}>`,
+        )
+        .replace("\\TReturn", "mixed")
+        .replace("TReturn", "mixed")
+        .replace("\\TValue", certainOfType ? className : "mixed")
+        .replace("TValue", certainOfType ? className : "mixed");
 
     return returnType;
 };
@@ -99,7 +101,7 @@ const getBlocks = (
         .concat(
             [...model.scopes, "newModelQuery", "newQuery", "query"].map(
                 (method) => {
-                    return `@method static \\Illuminate\\Database\\Eloquent\\Builder|${className} ${method}()`;
+                    return `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}> ${method}()`;
                 },
             ),
         )
@@ -191,7 +193,7 @@ const getAttributeBlocks = (
 
     if (!["accessor", "attribute"].includes(attr.cast || "")) {
         blocks.push(
-            `@method static \\Illuminate\\Database\\Eloquent\\Builder|${className} where${attr.title_case}($value)`,
+            `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}> where${attr.title_case}($value)`,
         );
     }
 

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -110,7 +110,7 @@ const getBlocks = (
         .concat(
             [...model.scopes, "newModelQuery", "newQuery", "query"].map(
                 (method) => {
-                    return `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}> ${method}()`;
+                    return `@method static \\Illuminate\\Database\\Eloquent\\Builder<${className}>|${className} ${method}()`;
                 },
             ),
         )

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -92,6 +92,10 @@ const getBuilderReturnType = (
         .replace("\\TValue", certainOfType ? className : "mixed")
         .replace("TValue", certainOfType ? className : "mixed")
         .replace("object", certainOfType ? className : "mixed");
+    
+    if (returnType.includes("mixed")) {
+        return "mixed";
+    };
 
     return returnType;
 };

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -72,6 +72,10 @@ const getBuilderReturnType = (
         return "void";
     }
 
+    if (["when", "unless"].includes(method.name)) {
+        return "mixed";
+    }
+
     if (["static", "self"].includes(method.return)) {
         return `\\Illuminate\\Database\\Eloquent\\Builder<${className}>`;
     }

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -90,7 +90,8 @@ const getBuilderReturnType = (
         .replace("\\TReturn", "mixed")
         .replace("TReturn", "mixed")
         .replace("\\TValue", certainOfType ? className : "mixed")
-        .replace("TValue", certainOfType ? className : "mixed");
+        .replace("TValue", certainOfType ? className : "mixed")
+        .replace("object", certainOfType ? className : "mixed");
 
     return returnType;
 };


### PR DESCRIPTION
Hi Joe!

Congrats on the launch of 1.0! 🚀

Also thanks for reviewing and merging https://github.com/laravel/vs-code-extension/pull/258.

I have another suggestion to the extension.

## Enable Eloquent Model property auto-complete after sole, find, first, or firstOrFail

Currently, we don't get Eloquent Model property auto-complete when we build an Eloquent query that ends in `sole`, `find`, `first`, or `firstOrFail`, even though it can only be an instance of the Model (or `null` in the case of `find` and `first`).

Example:

```php
$user = User::whereEmail('freerk@example.com')->sole();
$user->... // This will not auto-complete with e.g. `id`
````

However, if instead of type-hinting `\Illuminate\Database\Eloquent\Builder|User`, we type-hint  `\Illuminate\Database\Eloquent\Builder<User>|User`, we let the IDE know that we are returning an instance of Builder where the `TModel` generic template is an instance of the `User` model.

Now, when we try the same code as above, the IDE will actually be able to type-hint all properties on User as we would expect:

```php
$user = User::whereEmail('freerk@example.com')->sole();
$user->id;
````

I hope I have interpreted the problem correctly and that this change does not break other use-cases. 

It would be great if there were some tests that we can use to verify these kinds of changes. I would be willing to take a look at that -- the Eloquent part at least.

## Some other minor tweaks

- Move the "simple" early returns higher up in `getBuilderReturnType`.
- Make `when` and `unless` return "mixed", since we can never be certain of their return type.
- Add `"object"` as a candidate for replacement to fix `find`.
- Prevent `getBuilderReturnType` from returning "mixed" as a union type.

## PS: Also enables type-hinting on the result of `get()`.

I just realized today that this change also enables type-hinting when iterating over the result of `get()`

E.g.

```php
$users = User::query()->whereName('Freerk')->get()->each(fn ($user) => $user->id);
```