### PR TITLE
Added cast custom return type from get method

### DIFF
--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -53,25 +53,23 @@ function getBuilderMethod($method, $factory)
     ];
 }
 
-function getCastReturnType($classname)
+function getCastReturnType($className)
 {
-    if ($classname === null) {
+    if ($className === null) {
         return null;
     }
 
-    $returnType = $classname;
-
     try {
-        $class = new \ReflectionClass($classname);
+        $class = new \ReflectionClass($className);
         $method = $class->getMethod('get');
 
         if ($method->hasReturnType()) {
-            $returnType = $method->getReturnType()->getName();
+            return $method->getReturnType()->getName();
         }
 
-        return $returnType;
+        return $className;
     } catch (\Exception | \Throwable $e) {
-        return $returnType;
+        return $className;
     }
 }
 

--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -51,7 +51,29 @@ function getBuilderMethod($method, $factory)
         "parameters" => $params,
         "return" => $return,
     ];
-};
+}
+
+function getCastReturnType($classname)
+{
+    if ($classname === null) {
+        return null;
+    }
+
+    $returnType = $classname;
+
+    try {
+        $class = new \ReflectionClass($classname);
+        $method = $class->getMethod('get');
+
+        if ($method->hasReturnType()) {
+            $returnType = $method->getReturnType()->getName();
+        }
+
+        return $returnType;
+    } catch (\Exception | \Throwable $e) {
+        return $returnType;
+    }
+}
 
 function getModelInfo($className, $factory)
 {
@@ -91,6 +113,7 @@ function getModelInfo($className, $factory)
         ->map(fn($attrs) => array_merge($attrs, [
             'title_case' => str_replace('_', '', \Illuminate\Support\Str::title($attrs['name'])),
             'documented' => $existingProperties->contains($attrs['name']),
+            'cast' =>  getCastReturnType($attrs['cast'])
         ]))
         ->toArray();
 

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -55,8 +55,6 @@ function getBuilderMethod($method, $factory)
 
 function getCastReturnType($className)
 {
-    return $className;
-
     if ($className === null) {
         return null;
     }

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -51,7 +51,29 @@ function getBuilderMethod($method, $factory)
         "parameters" => $params,
         "return" => $return,
     ];
-};
+}
+
+function getCastReturnType($classname)
+{
+    if ($classname === null) {
+        return null;
+    }
+
+    $returnType = $classname;
+
+    try {
+        $class = new \\ReflectionClass($classname);
+        $method = $class->getMethod('get');
+
+        if ($method->hasReturnType()) {
+            $returnType = $method->getReturnType()->getName();
+        }
+
+        return $returnType;
+    } catch (\\Exception | \\Throwable $e) {
+        return $returnType;
+    }
+}
 
 function getModelInfo($className, $factory)
 {
@@ -91,6 +113,7 @@ function getModelInfo($className, $factory)
         ->map(fn($attrs) => array_merge($attrs, [
             'title_case' => str_replace('_', '', \\Illuminate\\Support\\Str::title($attrs['name'])),
             'documented' => $existingProperties->contains($attrs['name']),
+            'cast' =>  getCastReturnType($attrs['cast'])
         ]))
         ->toArray();
 

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -53,25 +53,25 @@ function getBuilderMethod($method, $factory)
     ];
 }
 
-function getCastReturnType($classname)
+function getCastReturnType($className)
 {
-    if ($classname === null) {
+    return $className;
+
+    if ($className === null) {
         return null;
     }
 
-    $returnType = $classname;
-
     try {
-        $class = new \\ReflectionClass($classname);
+        $class = new \\ReflectionClass($className);
         $method = $class->getMethod('get');
 
         if ($method->hasReturnType()) {
-            $returnType = $method->getReturnType()->getName();
+            return $method->getReturnType()->getName();
         }
 
-        return $returnType;
+        return $className;
     } catch (\\Exception | \\Throwable $e) {
-        return $returnType;
+        return $className;
     }
 }
 


### PR DESCRIPTION
Hi!

Thanks for this great extension!

This is my first contribution so I'm open to criticism and advices :)

Today I encountered a problem like the one described in issue #244 

### The type hinted is the Cast Class

The `Role.php` class has a `casts()` method:
```php
protected function casts(): array
{
    return [
        'catalog' => AsRoles::class,
        'product' => AsRoles::class,
    ];
}
```

The `AsRoles` class has a `get()` method:
```php
public function get(Model $model, string $key, mixed $value, array $attributes): Collection
{
    if (!isset($value)) return new Collection([]);
    return (new Stringable($value))->explode('|');
}
```

When I retrieved the casted value from the model I expected the type to be `Illuminate\Support\Collection`
Instead I got `App\Casts\AsRoles|null`.

With this change now I have what I expect: `Illuminate\Support\Collection|null`