### PR TITLE
Add parsing of immutable dates

### DIFF
--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -231,6 +231,7 @@ const castMapping: TypeMapping = {
     object: ["encrypted:object"],
     string: ["hashed"],
     "\\Illuminate\\Support\\Carbon": ["date", "datetime"],
+    "\\Carbon\\CarbonImmutable": ["immutable_date", "immutable_datetime"],
     "\\Illuminate\\Support\\Collection": ["encrypted:collection"],
 };
 


### PR DESCRIPTION
## Brief

This PR adds support for immutable date casts in the models

## What we currently have

- let's say we have a model with casts as shown below:

```php

protected $casts = [
    'example_date_1' => 'immutable_date',
    'example_date_2' => 'immutable_datetime',
];

```

- even in the stable version we will have the following in `_model_helpers.php`:

```php

@property immutable_date|null $example_date_1
@property immutable_datetime|null $example_date_2

```

## Fix

This fix is pretty simple, and as a result you should get the following in `_model_helpers.php`:


```php

@property \Carbon\CarbonImmutable|null $example_date_1
@property \Carbon\CarbonImmutable|null $example_date_2

```