### PR TITLE
Fix call to a member function get parameters on null

### DIFF
--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -98,7 +98,7 @@ $components = new class {
             }
 
             $reflection = new \ReflectionClass($class);
-            $parameters = collect($reflection->getConstructor()->getParameters())
+            $parameters = collect($reflection->getConstructor()?->getParameters() ?? [])
                 ->filter(fn($p) => $p->isPromoted())
                 ->flatMap(fn($p) => [$p->getName() => $p->isOptional() ? $p->getDefaultValue() : null])
                 ->all();

--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -90,6 +90,7 @@ $components = new class {
             $class = \Illuminate\Support\Str::of($item['path'])
                 ->after('View/Components/')
                 ->replace('.php', '')
+                ->replace('/', '\\')
                 ->prepend($appNamespace . 'View\\Components\\')
                 ->toString();
 

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -98,7 +98,7 @@ $components = new class {
             }
 
             $reflection = new \\ReflectionClass($class);
-            $parameters = collect($reflection->getConstructor()->getParameters())
+            $parameters = collect($reflection->getConstructor()?->getParameters() ?? [])
                 ->filter(fn($p) => $p->isPromoted())
                 ->flatMap(fn($p) => [$p->getName() => $p->isOptional() ? $p->getDefaultValue() : null])
                 ->all();

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -90,6 +90,7 @@ $components = new class {
             $class = \\Illuminate\\Support\\Str::of($item['path'])
                 ->after('View/Components/')
                 ->replace('.php', '')
+                ->replace('/', '\\\\')
                 ->prepend($appNamespace . 'View\\\\Components\\\\')
                 ->toString();
 


### PR DESCRIPTION
If the component class doesn't have a constructor, then the extenstion throws the error:

```
Call to a member function getParameters() on null

  at vendor/_laravel_ide/discover-22714b73385a058b04e3a7701bb39679.php:166
```
This PR fixes this issue.

Besides, I added additional replace slashes into backslashes in the class path. Without this, component classes are not found, and consequently the component attributes are not displayed in hover.