### PR TITLE
Support for vendor components

### DIFF
--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -209,9 +209,9 @@ $components = new class {
 
         foreach ($views as $key => $paths) {
             // First is always optional override in the resources/views folder
-            $path = $paths[0].'/components';
+            $path = $paths[0] . '/components';
 
-            if (! is_dir($path)) {
+            if (!is_dir($path)) {
                 continue;
             }
 

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -19,6 +19,7 @@ $components = new class {
             $this->getAnonymousNamespaced(),
             $this->getAnonymous(),
             $this->getAliases(),
+            $this->getVendorComponents(),
         ))->groupBy('key')->map(fn($items) => [
             'isVendor' => $items->first()['isVendor'],
             'paths' => $items->pluck('path')->values(),
@@ -188,6 +189,40 @@ $components = new class {
             if (!in_array($item['prefix'], $this->prefixes)) {
                 $this->prefixes[] = $item['prefix'];
             }
+        }
+
+        return $components;
+    }
+
+    protected function getVendorComponents(): array
+    {
+        $components = [];
+
+        /** @var \\Illuminate\\View\\Factory $view */
+        $view = \\Illuminate\\Support\\Facades\\App::make('view');
+
+        /** @var \\Illuminate\\View\\FileViewFinder $finder */
+        $finder = $view->getFinder();
+
+        /** @var array<string, array<int, string>> $views */
+        $views = $finder->getHints();
+
+        foreach ($views as $key => $paths) {
+            // First is always optional override in the resources/views folder
+            $path = $paths[0].'/components';
+
+            if (! is_dir($path)) {
+                continue;
+            }
+
+            array_push(
+                $components,
+                ...$this->findFiles(
+                    $path,
+                    'blade.php',
+                    fn (\\Illuminate\\Support\\Stringable $k) => $k->kebab()->prepend($key.'::'),
+                )
+            );
         }
 
         return $components;

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -209,9 +209,9 @@ $components = new class {
 
         foreach ($views as $key => $paths) {
             // First is always optional override in the resources/views folder
-            $path = $paths[0].'/components';
+            $path = $paths[0] . '/components';
 
-            if (! is_dir($path)) {
+            if (!is_dir($path)) {
                 continue;
             }
 


### PR DESCRIPTION
This PR adds support for hovering and linking for vendor blade components. There is also support for overrides in the resources/views folder.

Before:

![before](https://github.com/user-attachments/assets/19c66e56-4c26-41f5-8a8a-3653878fa8e3)

After:

![after](https://github.com/user-attachments/assets/5f00944d-b42d-4252-82a3-c6b1e50a4fed)

This feature needs more testing.