### PR TITLE
Fix parsing of unsupported language files

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -189,11 +189,16 @@ $translator = new class
 
     protected function getDotted($key, $lang)
     {
-        return \Illuminate\Support\Arr::dot(
-            \Illuminate\Support\Arr::wrap(
-                __($key, [], $lang),
-            ),
-        );
+        try {
+            return \Illuminate\Support\Arr::dot(
+                \Illuminate\Support\Arr::wrap(
+                    __($key, [], $lang),
+                ),
+            );
+        } catch (\Throwable $e) {
+            // Most likely, in this case, the lang file doesn't return an array
+            return [];
+        }
     }
 
     protected function getPathIndex($file)

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -189,11 +189,16 @@ $translator = new class
 
     protected function getDotted($key, $lang)
     {
-        return \\Illuminate\\Support\\Arr::dot(
-            \\Illuminate\\Support\\Arr::wrap(
-                __($key, [], $lang),
-            ),
-        );
+        try {
+            return \\Illuminate\\Support\\Arr::dot(
+                \\Illuminate\\Support\\Arr::wrap(
+                    __($key, [], $lang),
+                ),
+            );
+        } catch (\\Throwable $e) {
+            // Most likely, in this case, the lang file doesn't return an array
+            return [];
+        }
     }
 
     protected function getPathIndex($file)


### PR DESCRIPTION
## Brief

This PR fixes parsing of unsupported language files
 
### Brief

This happens rarely, but sometimes language files have been created incorrectly, so they can't be parsed. Some examples:

```php
<?php
// TODO: add localization strings here
```

```php
<?php
$localizations = ['foo' => 'bar'];
```

Both files don't return an array. Of course, the core Laravel code will throw a fatal error. **_BUT_** in order to see this error, you have to use these language files somewhere in the code. However, these files may be unused for some reason: TODO for the future, or simply forgotten. So, you will never see this error

### Long story short

If there are such files in the project, you will see this error in VS code output:
<img width="779" alt="Screenshot 2025-03-07 at 18 18 32" src="https://github.com/user-attachments/assets/cf5ccddb-3d83-4681-8855-075b841e0a7c" />

Then, all the benefits of Laravel VS code extension for translations will be broken:
<img width="485" alt="Screenshot 2025-03-07 at 18 19 52" src="https://github.com/user-attachments/assets/722be892-6816-4f03-aa8a-31009385e73d" />

Implementing the fix from this PR, should ignore such files and everything will work fine with other language files:
<img width="485" alt="Screenshot 2025-03-07 at 18 20 31" src="https://github.com/user-attachments/assets/501cdf9a-9127-41c1-9d83-1e1b85f2f891" />

---
Perhaps this can be considered a problem of the developer who left such language files. But i think it shouldn't break all the translation features provided by this extension. Especially since it's not too easy to determine what's wrong when you see the error in the first screenshot