### PR TITLE
Support for translations in files in subfolders

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -328,16 +328,16 @@ $translator = new class
 
     protected function fromPhpFile($file, $path, $namespace)
     {
-        $relativePath = str(realpath($file))
-            ->after(realpath($path)) // Firstly remove the path to the /lang folder
-            ->ltrim(DIRECTORY_SEPARATOR);
+        $lang = str($file)
+            ->after($path.DIRECTORY_SEPARATOR)
+            ->before(DIRECTORY_SEPARATOR)
+            ->value();
 
-        $lang = $relativePath->before(DIRECTORY_SEPARATOR)->toString();
-
-        $key = $relativePath
-            ->after(DIRECTORY_SEPARATOR) // Remove the language folder for example /en, /pl etc.
-            ->replace('.php', '') // Then remove the .php extension
-            ->toString();
+        $key = str($file)
+            ->after($path.DIRECTORY_SEPARATOR)
+            ->after(DIRECTORY_SEPARATOR)
+            ->replaceLast('.php', '')
+            ->value();
 
         if ($namespace) {
             $key = "{$namespace}::{$key}";

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -54,11 +54,11 @@ $models = new class($factory) {
 
     public function all()
     {
-            if (\\Illuminate\\Support\\Facades\\File::isDirectory(base_path('app/Models'))) {
-                collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
-                    ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
-                    ->each(fn($file) => include_once($file));
-            }
+        if (\\Illuminate\\Support\\Facades\\File::isDirectory(base_path('app/Models'))) {
+            collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
+                ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
+                ->each(fn($file) => include_once($file));
+        }
 
         return collect(get_declared_classes())
             ->filter(fn($class) => is_subclass_of($class, \\Illuminate\\Database\\Eloquent\\Model::class))

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -328,16 +328,16 @@ $translator = new class
 
     protected function fromPhpFile($file, $path, $namespace)
     {
-        $relativePath = str(realpath($file))
-            ->after(realpath($path)) // Firstly remove the path to the /lang folder
-            ->ltrim(DIRECTORY_SEPARATOR);
+        $lang = str($file)
+            ->after($path.DIRECTORY_SEPARATOR)
+            ->before(DIRECTORY_SEPARATOR)
+            ->value();
 
-        $lang = $relativePath->before(DIRECTORY_SEPARATOR)->toString();
-
-        $key = $relativePath
-            ->after(DIRECTORY_SEPARATOR) // Remove the language folder for example /en, /pl etc.
-            ->replace('.php', '') // Then remove the .php extension
-            ->toString();
+        $key = str($file)
+            ->after($path.DIRECTORY_SEPARATOR)
+            ->after(DIRECTORY_SEPARATOR)
+            ->replaceLast('.php', '')
+            ->value();
 
         if ($namespace) {
             $key = "{$namespace}::{$key}";


### PR DESCRIPTION
This PR adds support for translations in files in subfolders. For example, Filament uses such files.

Before:

![before](https://github.com/user-attachments/assets/72566c22-2fe8-40a2-b81c-4c5cc73c39ca)

After:

![after](https://github.com/user-attachments/assets/d716e8a5-b258-42e2-afb8-b6da4e749143)

This feature needs more testing.

Fixes https://github.com/laravel/vs-code-extension/issues/282