### PR TITLE
Add link to blade file for MailMessage::markdown/view

### DIFF
--- a/src/features/view.ts
+++ b/src/features/view.ts
@@ -37,6 +37,11 @@ const toFind: FeatureTag = [
         argumentIndex: 1,
     },
     {
+        class: "Illuminate\\Notifications\\Messages\\MailMessage",
+        method: ["markdown", "view"],
+        argumentIndex: 0,
+    },
+    {
         class: "Illuminate\\Mail\\Mailables\\Content",
         argumentName: ["view", "markdown"],
     },


### PR DESCRIPTION
This PR adds support for links and hovers for MailMessage::markdown/view methods.

Fixes https://github.com/laravel/vs-code-extension/issues/315