### PR TITLE
Option to disable model doc block generation + fix doc block extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,11 @@
                     "default": true,
                     "description": "Show popups for errors."
                 },
+                "Laravel.eloquent.generateDocBlocks": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Automatically generate Eloquent doc blocks for models as IDE helpers."
+                },
                 "Laravel.blade.autoSpaceTags": {
                     "type": "boolean",
                     "default": true,

--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -119,13 +119,30 @@ $models = new class($factory) {
         return collect();
     }
 
+    protected function getParentClass(\ReflectionClass $reflection)
+    {
+        if (!$reflection->getParentClass()) {
+            return null;
+        }
+
+        $parent = $reflection->getParentClass()->getName();
+
+        if ($parent === \Illuminate\Database\Eloquent\Model::class) {
+            return null;
+        }
+
+        return \Illuminate\Support\Str::start($parent, '\\');
+    }
+
     protected function getInfo($className)
     {
         if (($data = $this->fromArtisan($className)) === null) {
             return null;
         }
 
-        $reflection = (new \ReflectionClass($className));
+        $reflection = new \ReflectionClass($className);
+
+        $data["extends"] = $this->getParentClass($reflection);
 
         $existingProperties = $this->collectExistingProperties($reflection);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,7 @@ declare namespace Eloquent {
         events: Event[];
         observers: Observer[];
         scopes: string[];
+        extends: string | null;
     }
 
     interface Attribute {

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -10,7 +10,8 @@ type ConfigKey =
     | "tests.ssh.enabled"
     | "tests.suiteSuffix"
     | "showErrorPopups"
-    | "blade.autoSpaceTags";
+    | "blade.autoSpaceTags"
+    | "eloquent.generateDocBlocks";
 
 export const config = <T>(key: ConfigKey, fallback: T): T =>
     vscode.workspace.getConfiguration("Laravel").get<T>(key, fallback);

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { Eloquent } from "..";
+import { config } from "./config";
 import { internalVendorPath } from "./project";
 import { indent } from "./util";
 
@@ -16,7 +17,7 @@ export const writeEloquentDocBlocks = (
     models: Eloquent.Models,
     builderMethods: Eloquent.BuilderMethod[],
 ) => {
-    if (!models) {
+    if (!models || !config("eloquent.generateDocBlocks", true)) {
         return;
     }
 
@@ -113,7 +114,9 @@ const getBlocks = (
         .concat(
             [...model.scopes, "newModelQuery", "newQuery", "query"].map(
                 (method) => {
-                    return `@method static ${modelBuilderType(className)} ${method}()`;
+                    return `@method static ${modelBuilderType(
+                        className,
+                    )} ${method}()`;
                 },
             ),
         )
@@ -205,7 +208,9 @@ const getAttributeBlocks = (
 
     if (!["accessor", "attribute"].includes(attr.cast || "")) {
         blocks.push(
-            `@method static ${modelBuilderType(className)} where${attr.title_case}($value)`,
+            `@method static ${modelBuilderType(className)} where${
+                attr.title_case
+            }($value)`,
         );
     }
 

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -8,6 +8,7 @@ interface ClassBlock {
     namespace: string;
     className: string;
     blocks: string[];
+    extends: string | null;
 }
 
 const modelBuilderType = (className: string) =>
@@ -29,6 +30,7 @@ export const writeEloquentDocBlocks = (
             namespace: pathParts.join("\\"),
             className: cls || "",
             blocks: getBlocks(model, cls || "", builderMethods),
+            extends: model.extends || null,
         };
     });
 
@@ -181,7 +183,9 @@ const classToDocBlock = (block: ClassBlock, namespace: string) => {
         ...block.blocks,
         " * @mixin \\Illuminate\\Database\\Query\\Builder",
         " */",
-        `class ${block.className} extends \\Illuminate\\Database\\Eloquent\\Model`,
+        `class ${block.className} extends ${
+            block.extends ?? "\\Illuminate\\Database\\Eloquent\\Model"
+        }`,
         `{`,
         indent("//"),
         `}`,

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -119,13 +119,30 @@ $models = new class($factory) {
         return collect();
     }
 
+    protected function getParentClass(\\ReflectionClass $reflection)
+    {
+        if (!$reflection->getParentClass()) {
+            return null;
+        }
+
+        $parent = $reflection->getParentClass()->getName();
+
+        if ($parent === \\Illuminate\\Database\\Eloquent\\Model::class) {
+            return null;
+        }
+
+        return \\Illuminate\\Support\\Str::start($parent, '\\\\');
+    }
+
     protected function getInfo($className)
     {
         if (($data = $this->fromArtisan($className)) === null) {
             return null;
         }
 
-        $reflection = (new \\ReflectionClass($className));
+        $reflection = new \\ReflectionClass($className);
+
+        $data["extends"] = $this->getParentClass($reflection);
 
         $existingProperties = $this->collectExistingProperties($reflection);
 


### PR DESCRIPTION
This PR adds a config option to disable doc block generation (Laravel › Eloquent: Generate Doc Blocks).

It also fixes scenarios where the model is extending a custom class and reflects that accurately in the generated doc blocks.