### PR TITLE
Fix laravel vs coderelative path when path does not exist

### DIFF
--- a/php-templates/bootstrap-laravel.php
+++ b/php-templates/bootstrap-laravel.php
@@ -14,7 +14,7 @@ class LaravelVsCode
             return (string) $path;
         }
 
-        return ltrim(str_replace(base_path(), '', realpath($path)), DIRECTORY_SEPARATOR);
+        return ltrim(str_replace(base_path(), '', realpath($path) ?: $path), DIRECTORY_SEPARATOR);
     }
 
     public static function isVendor($path)

--- a/src/templates/bootstrap-laravel.ts
+++ b/src/templates/bootstrap-laravel.ts
@@ -14,7 +14,7 @@ class LaravelVsCode
             return (string) $path;
         }
 
-        return ltrim(str_replace(base_path(), '', realpath($path)), DIRECTORY_SEPARATOR);
+        return ltrim(str_replace(base_path(), '', realpath($path) ?: $path), DIRECTORY_SEPARATOR);
     }
 
     public static function isVendor($path)


### PR DESCRIPTION
There is a bug with LaravelVsCode::relativePath method. If the path does not exist, the php function _realpath_ returns false and _str_replace_ throws error:

> TypeError  str_replace(): Argument #3 ($subject) must be of type array|string, false given.

This PR fixes this problem