### PR TITLE
Fix PHP String Concatenation in Output Panel Interpreted as Shell Commands

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -121,7 +121,7 @@ const cleanArg = (arg: string): string => {
     ) {
         replacements.push([/\$/g, "\\$"]);
         replacements.push([/\\'/g, "\\\\'"]);
-        replacements.push([/\\"/g, '\\\\"']);
+        replacements.push([/\\"/g, '\\\"']);
     }
 
     replacements.push([/\"/g, '\\"']);


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/271

There is a bug. If the contents of the file with the PHP code contains string with concatenation for example:

```php
<?php

$className = "App\\DynamicApp\\Models\\" . ucfirst($relationshipField->attribute) . "Model";
```

then the command will look like this:

```
php-parser detect "<?php

\$className = \"App\\DynamicApp\\Models\\\\" . ucfirst(\$relationshipField->attribute) . \"Model\";
```

There is one more backslash after "Models\\\\" than there should be. Then the command returns an error:

`bash: syntax error near unexpected token `('`

I suggest to remove one backslash from replacements in the cleanArg method:

```js
replacements.push([/\\"/g, '\\\"']);
```

because 2nd replacement in the line:

```js
replacements.push([/\"/g, '\\"']);
```

duplicates backslashes in that case.