### PR TITLE
Improve file watcher performance

### DIFF
--- a/php-templates/inertia.php
+++ b/php-templates/inertia.php
@@ -1,11 +1,6 @@
 <?php
 
-$config = config('inertia.testing', []);
-
-$pagePaths = collect($config['page_paths'] ?? [])->map(function($path) {
-    return LaravelVsCode::relativePath($path);
-});
-
-$config['page_paths'] = $pagePaths->toArray();
-
-echo json_encode($config);
+echo json_encode([
+    ...config('inertia.testing', []),
+    'page_paths' => collect(config('inertia.testing.page_paths', []))->map(fn($path) => LaravelVsCode::relativePath($path))->toArray(),
+]);

--- a/php-templates/routes.php
+++ b/php-templates/routes.php
@@ -93,5 +93,4 @@ $routes = new class {
     }
 };
 
-
 echo $routes->all()->toJson();

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -12,6 +12,8 @@ $translator = new class
 
     public $emptyParams = [];
 
+    public $directoriesToWatch = [];
+
     public function all()
     {
         $final = [];
@@ -80,6 +82,10 @@ $translator = new class
 
         if (!is_dir($realPath)) {
             return [];
+        }
+
+        if (!LaravelVsCode::isVendor($realPath)) {
+            $this->directoriesToWatch[] = LaravelVsCode::relativePath($realPath);
         }
 
         return array_map(
@@ -342,4 +348,5 @@ echo json_encode([
     'paths' => array_keys($translator->paths),
     'values' => array_keys($translator->values),
     'params' => array_map(fn($p) => json_decode($p, true), array_keys($translator->paramResults)),
+    'to_watch' => $translator->directoriesToWatch,
 ]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 
 import os from "os";
 import { LanguageClient } from "vscode-languageclient/node";
+import { bladeSpacer } from "./blade/bladeSpacer";
 import { initClient } from "./blade/client";
 import { CodeActionProvider } from "./codeAction/codeActionProvider";
 import { openFileCommand } from "./commands";
@@ -19,13 +20,15 @@ import { hoverProviders } from "./hover/HoverProvider";
 import { linkProviders } from "./link/LinkProvider";
 import { configAffected } from "./support/config";
 import { collectDebugInfo } from "./support/debug";
-import { disposeWatchers } from "./support/fileWatcher";
+import {
+    disposeWatchers,
+    watchForComposerChanges,
+} from "./support/fileWatcher";
 import { info } from "./support/logger";
 import { setParserBinaryPath } from "./support/parser";
 import { clearDefaultPhpCommand, initVendorWatchers } from "./support/php";
 import { hasWorkspace, projectPathExists } from "./support/project";
 import { cleanUpTemp } from "./support/util";
-import { bladeSpacer } from "./blade/bladeSpacer";
 
 let client: LanguageClient;
 
@@ -65,6 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
     const LANGUAGES = [{ scheme: "file", language: "php" }, ...BLADE_LANGUAGES];
 
     initVendorWatchers();
+    watchForComposerChanges();
     setParserBinaryPath(context);
 
     const TRIGGER_CHARACTERS = ["'", '"'];

--- a/src/repositories/appBinding.ts
+++ b/src/repositories/appBinding.ts
@@ -9,10 +9,10 @@ type AppBindingItem = {
     };
 };
 
-export const getAppBindings = repository<AppBindingItem>(
-    () => {
+export const getAppBindings = repository<AppBindingItem>({
+    load: () => {
         return runInLaravel<AppBindingItem>(template("app"), "App Bindings");
     },
-    "app/Providers/{,*,**/*}.php",
-    {},
-);
+    pattern: "app/Providers/{,*,**/*}.php",
+    itemsDefault: {},
+});

--- a/src/repositories/asset.ts
+++ b/src/repositories/asset.ts
@@ -53,8 +53,8 @@ const getFilesInDirectory = (dir: string, depth: number = 0): Item[] => {
         .flat();
 };
 
-export const getAssets = repository<Item[]>(
-    () =>
+export const getAssets = repository<Item[]>({
+    load: () =>
         new Promise((resolve, reject) => {
             try {
                 resolve(getFilesInDirectory("public"));
@@ -62,6 +62,7 @@ export const getAssets = repository<Item[]>(
                 reject(exception);
             }
         }),
-    "public/**/*",
-    [],
-);
+    pattern: "public/**/*",
+    itemsDefault: [],
+    reloadOnComposerChanges: false,
+});

--- a/src/repositories/auth.ts
+++ b/src/repositories/auth.ts
@@ -16,8 +16,8 @@ const load = () => {
     return runInLaravel<AuthItems>(template("auth"), "Auth Data");
 };
 
-export const getPolicies = repository<AuthItems>(
+export const getPolicies = repository<AuthItems>({
     load,
-    "app/Providers/{,*,**/*}.php",
-    {},
-);
+    pattern: "app/Providers/{,*,**/*}.php",
+    itemsDefault: {},
+});

--- a/src/repositories/bladeComponents.ts
+++ b/src/repositories/bladeComponents.ts
@@ -1,3 +1,4 @@
+import { inAppDirs } from "@src/support/fileWatcher";
 import { runInLaravel, template } from "@src/support/php";
 import { repository } from ".";
 
@@ -22,7 +23,10 @@ const load = () => {
 
 export const getBladeComponents = repository<BladeComponents>(
     load,
-    ["{,**/}{view,views}/{*,**/*}", "app/View/Components/{,*,**/*}.php"],
+    [
+        inAppDirs("{,**/}{view,views}/{*,**/*}"),
+        "app/View/Components/{,*,**/*}.php",
+    ],
     {
         components: {},
         prefixes: [],

--- a/src/repositories/bladeComponents.ts
+++ b/src/repositories/bladeComponents.ts
@@ -21,15 +21,15 @@ const load = () => {
     return runInLaravel<BladeComponents>(template("bladeComponents"));
 };
 
-export const getBladeComponents = repository<BladeComponents>(
+export const getBladeComponents = repository<BladeComponents>({
     load,
-    [
+    pattern: [
         inAppDirs("{,**/}{view,views}/{*,**/*}"),
         "app/View/Components/{,*,**/*}.php",
     ],
-    {
+    itemsDefault: {
         components: {},
         prefixes: [],
     },
-    ["create", "delete"],
-);
+    fileWatcherEvents: ["create", "delete"],
+});

--- a/src/repositories/configs.ts
+++ b/src/repositories/configs.ts
@@ -2,8 +2,8 @@ import { repository } from ".";
 import { Config } from "..";
 import { runInLaravel, template } from "../support/php";
 
-export const getConfigs = repository<Config[]>(
-    () => {
+export const getConfigs = repository<Config[]>({
+    load: () => {
         return runInLaravel<Config[]>(template("configs"), "Configs").then(
             (result) =>
                 result.map((item) => {
@@ -16,6 +16,6 @@ export const getConfigs = repository<Config[]>(
                 }),
         );
     },
-    ["config/{,*,**/*}.php", ".env"],
-    [],
-);
+    pattern: ["config/{,*,**/*}.php", ".env"],
+    itemsDefault: [],
+});

--- a/src/repositories/controllers.ts
+++ b/src/repositories/controllers.ts
@@ -1,3 +1,4 @@
+import { inAppDirs } from "@src/support/fileWatcher";
 import * as fs from "fs";
 import { repository } from ".";
 import { projectPath } from "../support/project";
@@ -80,6 +81,6 @@ export const getControllers = repository<string[]>(
             resolve(load());
         });
     },
-    "{,**/}{Controllers}{.php,/*.php,/**/*.php}",
+    inAppDirs("{,**/}{Controllers}{.php,/*.php,/**/*.php}"),
     [],
 );

--- a/src/repositories/controllers.ts
+++ b/src/repositories/controllers.ts
@@ -75,12 +75,12 @@ const collectControllers = (path: string): string[] => {
     return [...controllers];
 };
 
-export const getControllers = repository<string[]>(
-    () => {
+export const getControllers = repository<string[]>({
+    load: () => {
         return new Promise((resolve) => {
             resolve(load());
         });
     },
-    inAppDirs("{,**/}{Controllers}{.php,/*.php,/**/*.php}"),
-    [],
-);
+    pattern: inAppDirs("{,**/}{Controllers}{.php,/*.php,/**/*.php}"),
+    itemsDefault: [],
+});

--- a/src/repositories/customBladeDirectives.ts
+++ b/src/repositories/customBladeDirectives.ts
@@ -6,12 +6,12 @@ interface CustomDirectiveItem {
     hasParams: boolean;
 }
 
-export const getCustomBladeDirectives = repository<CustomDirectiveItem[]>(
-    () =>
+export const getCustomBladeDirectives = repository<CustomDirectiveItem[]>({
+    load: () =>
         runInLaravel<CustomDirectiveItem[]>(
             template("bladeDirectives"),
             "Custom Blade Directives",
         ),
-    "app/{,*,**/*}Provider.php",
-    [],
-);
+    pattern: "app/{,*,**/*}Provider.php",
+    itemsDefault: [],
+});

--- a/src/repositories/env-example.ts
+++ b/src/repositories/env-example.ts
@@ -41,8 +41,8 @@ const load = () => {
     return items;
 };
 
-export const getEnvExample = repository<EnvItem>(
-    () =>
+export const getEnvExample = repository<EnvItem>({
+    load: () =>
         new Promise<EnvItem>((resolve, reject) => {
             try {
                 resolve(load());
@@ -50,6 +50,7 @@ export const getEnvExample = repository<EnvItem>(
                 reject(error);
             }
         }),
-    filename,
-    {},
-);
+    pattern: filename,
+    itemsDefault: {},
+    reloadOnComposerChanges: false,
+});

--- a/src/repositories/env.ts
+++ b/src/repositories/env.ts
@@ -45,8 +45,8 @@ const load = () => {
     return items;
 };
 
-export const getEnv = repository<EnvItem>(
-    () =>
+export const getEnv = repository<EnvItem>({
+    load: () =>
         new Promise<EnvItem>((resolve, reject) => {
             try {
                 resolve(load());
@@ -54,6 +54,7 @@ export const getEnv = repository<EnvItem>(
                 reject(error);
             }
         }),
-    ".env",
-    {},
-);
+    pattern: ".env",
+    itemsDefault: {},
+    reloadOnComposerChanges: false,
+});

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,15 +1,23 @@
 import {
+    type FileEvent,
     WatcherPattern,
     defaultFileEvents,
     loadAndWatch,
 } from "../support/fileWatcher";
 
-export const repository = <T>(
-    load: () => Promise<T>,
-    pattern: WatcherPattern,
-    itemsDefault: T,
+export const repository = <T>({
+    load,
+    pattern,
+    itemsDefault,
     fileWatcherEvents = defaultFileEvents,
-) => {
+    reloadOnComposerChanges = true,
+}: {
+    load: () => Promise<T>;
+    pattern: WatcherPattern;
+    itemsDefault: T;
+    fileWatcherEvents?: FileEvent[];
+    reloadOnComposerChanges?: boolean;
+}) => {
     let items: T = itemsDefault;
     let loaded = false;
 
@@ -30,6 +38,7 @@ export const repository = <T>(
         },
         pattern,
         fileWatcherEvents,
+        reloadOnComposerChanges,
     );
 
     const whenLoaded = async (callback: (items: T) => any, maxTries = 20) => {

--- a/src/repositories/inertia.ts
+++ b/src/repositories/inertia.ts
@@ -77,8 +77,8 @@ const collectViews = (
         .flat();
 };
 
-export const getInertiaViews = repository<ViewItem>(
-    () =>
+export const getInertiaViews = repository<ViewItem>({
+    load: () =>
         runInLaravel<{
             page_paths?: string[];
             page_extensions?: string[];
@@ -88,7 +88,7 @@ export const getInertiaViews = repository<ViewItem>(
                 result?.page_extensions ?? [],
             );
         }),
-    () =>
+    pattern: () =>
         waitForValue(() => inertiaPagePaths).then((pagePaths) => {
             if (pagePaths === null || pagePaths.length === 0) {
                 return null;
@@ -96,6 +96,6 @@ export const getInertiaViews = repository<ViewItem>(
 
             return `{${pagePaths.join(",")}}/{*,**/*}`;
         }),
-    {},
-    ["create", "delete"],
-);
+    itemsDefault: {},
+    fileWatcherEvents: ["create", "delete"],
+});

--- a/src/repositories/inertia.ts
+++ b/src/repositories/inertia.ts
@@ -1,5 +1,6 @@
 import { runInLaravel, template } from "@src/support/php";
 import { projectPath, relativePath } from "@src/support/project";
+import { waitForValue } from "@src/support/util";
 import * as fs from "fs";
 import * as sysPath from "path";
 import { repository } from ".";
@@ -88,20 +89,12 @@ export const getInertiaViews = repository<ViewItem>(
             );
         }),
     () =>
-        new Promise((resolve) => {
-            const checkForPagePaths = () => {
-                if (inertiaPagePaths === null) {
-                    return setTimeout(checkForPagePaths, 100);
-                }
+        waitForValue(() => inertiaPagePaths).then((pagePaths) => {
+            if (pagePaths === null || pagePaths.length === 0) {
+                return null;
+            }
 
-                if (inertiaPagePaths.length === 0) {
-                    resolve(null);
-                } else {
-                    resolve(`{${inertiaPagePaths.join(",")}}/{*,**/*}`);
-                }
-            };
-
-            checkForPagePaths();
+            return `{${pagePaths.join(",")}}/{*,**/*}`;
         }),
     {},
     ["create", "delete"],

--- a/src/repositories/middleware.ts
+++ b/src/repositories/middleware.ts
@@ -15,8 +15,8 @@ interface MiddlewareItem {
     };
 }
 
-export const getMiddleware = repository<MiddlewareItem>(
-    () => {
+export const getMiddleware = repository<MiddlewareItem>({
+    load: () => {
         return runInLaravel<MiddlewareItem>(
             template("middleware"),
             "Middlewares",
@@ -40,7 +40,7 @@ export const getMiddleware = repository<MiddlewareItem>(
             return items;
         });
     },
-    "app/Http/Kernel.php",
-    {},
-    ["change"],
-);
+    pattern: "app/Http/Kernel.php",
+    itemsDefault: {},
+    fileWatcherEvents: ["change"],
+});

--- a/src/repositories/mix.ts
+++ b/src/repositories/mix.ts
@@ -27,8 +27,8 @@ const load = () => {
     }));
 };
 
-export const getMixManifest = repository<MixManifestItem[]>(
-    () => {
+export const getMixManifest = repository<MixManifestItem[]>({
+    load: () => {
         return new Promise((resolve, reject) => {
             try {
                 resolve(load());
@@ -37,6 +37,7 @@ export const getMixManifest = repository<MixManifestItem[]>(
             }
         });
     },
-    "public/mix-manifest.json",
-    [],
-);
+    pattern: "public/mix-manifest.json",
+    itemsDefault: [],
+    reloadOnComposerChanges: false,
+});

--- a/src/repositories/models.ts
+++ b/src/repositories/models.ts
@@ -22,8 +22,10 @@ const load = () => {
     });
 };
 
-export const getModels = repository<Eloquent.Models>(
+export const getModels = repository<Eloquent.Models>({
     load,
-    modelPaths.concat(["database/migrations"]).map((path) => `${path}/*.php`),
-    {},
-);
+    pattern: modelPaths
+        .concat(["database/migrations"])
+        .map((path) => `${path}/*.php`),
+    itemsDefault: {},
+});

--- a/src/repositories/paths.ts
+++ b/src/repositories/paths.ts
@@ -6,8 +6,8 @@ interface PathItem {
     path: string;
 }
 
-export const getPaths = repository<PathItem[]>(
-    () => {
+export const getPaths = repository<PathItem[]>({
+    load: () => {
         return runInLaravel<{ key: string; path: string }[]>(
             `
             echo json_encode([
@@ -48,6 +48,7 @@ export const getPaths = repository<PathItem[]>(
             "Paths",
         );
     },
-    "config/{,*,**/*}.php",
-    [],
-);
+    pattern: "config/{,*,**/*}.php",
+    itemsDefault: [],
+    reloadOnComposerChanges: false,
+});

--- a/src/repositories/routes.ts
+++ b/src/repositories/routes.ts
@@ -14,10 +14,10 @@ interface RouteItem {
 
 const routesPattern = "{[Rr]oute}{,s}{.php,/*.php,/**/*.php}";
 
-export const getRoutes = repository<RouteItem[]>(
-    () => {
+export const getRoutes = repository<RouteItem[]>({
+    load: () => {
         return runInLaravel<RouteItem[]>(template("routes"), "HTTP Routes");
     },
-    [inAppDirs(`{,**/}${routesPattern}`), routesPattern],
-    [],
-);
+    pattern: [inAppDirs(`{,**/}${routesPattern}`), routesPattern],
+    itemsDefault: [],
+});

--- a/src/repositories/routes.ts
+++ b/src/repositories/routes.ts
@@ -1,3 +1,4 @@
+import { inAppDirs } from "@src/support/fileWatcher";
 import { repository } from ".";
 import { runInLaravel, template } from "../support/php";
 
@@ -11,10 +12,12 @@ interface RouteItem {
     line: number | null;
 }
 
+const routesPattern = "{[Rr]oute}{,s}{.php,/*.php,/**/*.php}";
+
 export const getRoutes = repository<RouteItem[]>(
     () => {
         return runInLaravel<RouteItem[]>(template("routes"), "HTTP Routes");
     },
-    "{,**/}{[Rr]oute}{,s}{.php,/*.php,/**/*.php}",
+    [inAppDirs(`{,**/}${routesPattern}`), routesPattern],
     [],
 );

--- a/src/repositories/translations.ts
+++ b/src/repositories/translations.ts
@@ -67,9 +67,9 @@ const load = () => {
     });
 };
 
-export const getTranslations = repository<TranslationGroupResult>(
+export const getTranslations = repository<TranslationGroupResult>({
     load,
-    () =>
+    pattern: () =>
         waitForValue(() => dirsToWatch).then((value) => {
             if (value === null || value.length === 0) {
                 return null;
@@ -77,8 +77,8 @@ export const getTranslations = repository<TranslationGroupResult>(
 
             return `{${value.join(",")}}/{*,**/*}`;
         }),
-    {
+    itemsDefault: {
         default: "",
         translations: {},
     },
-);
+});

--- a/src/repositories/views.ts
+++ b/src/repositories/views.ts
@@ -26,9 +26,9 @@ const load = () => {
     });
 };
 
-export const getViews = repository<ViewItem[]>(
+export const getViews = repository<ViewItem[]>({
     load,
-    inAppDirs("{,**/}{view,views}/{*,**/*}"),
-    [],
-    ["create", "delete"],
-);
+    pattern: inAppDirs("{,**/}{view,views}/{*,**/*}"),
+    itemsDefault: [],
+    fileWatcherEvents: ["create", "delete"],
+});

--- a/src/repositories/views.ts
+++ b/src/repositories/views.ts
@@ -1,3 +1,4 @@
+import { inAppDirs } from "@src/support/fileWatcher";
 import { runInLaravel, template } from "@src/support/php";
 import { repository } from ".";
 
@@ -27,7 +28,7 @@ const load = () => {
 
 export const getViews = repository<ViewItem[]>(
     load,
-    "{,**/}{view,views}/{*,**/*}",
+    inAppDirs("{,**/}{view,views}/{*,**/*}"),
     [],
     ["create", "delete"],
 );

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -100,16 +100,8 @@ export const createFileWatcher = (
             return patternWatchers[pattern].watcher;
         }
 
-        const relativePattern = new vscode.RelativePattern(
-            getWorkspaceFolders()[0],
-            pattern,
-        );
-
         const watcher = vscode.workspace.createFileSystemWatcher(
-            relativePattern,
-            !events.includes("create"),
-            !events.includes("change"),
-            !events.includes("delete"),
+            new vscode.RelativePattern(getWorkspaceFolders()[0], pattern),
         );
 
         watcher.onDidChange((...args) => {

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -100,3 +100,28 @@ export const leadingDebounce = <T extends (...args: any[]) => any>(
         lastInvocation = Date.now();
     } as T;
 };
+
+export const waitForValue = <T>(
+    value: () => T,
+    interval = 100,
+    maxAttempts = 20,
+): Promise<T> =>
+    new Promise((resolve) => {
+        let attempts = 0;
+
+        const checkForValue = () => {
+            attempts++;
+
+            if (attempts > maxAttempts) {
+                return resolve(value());
+            }
+
+            if (value() === null) {
+                return setTimeout(checkForValue, 100);
+            }
+
+            resolve(value());
+        };
+
+        checkForValue();
+    });

--- a/src/templates/inertia.ts
+++ b/src/templates/inertia.ts
@@ -1,12 +1,7 @@
 // This file was generated from php-templates/inertia.php, do not edit directly
 export default `
-$config = config('inertia.testing', []);
-
-$pagePaths = collect($config['page_paths'] ?? [])->map(function($path) {
-    return LaravelVsCode::relativePath($path);
-});
-
-$config['page_paths'] = $pagePaths->toArray();
-
-echo json_encode($config);
+echo json_encode([
+    ...config('inertia.testing', []),
+    'page_paths' => collect(config('inertia.testing.page_paths', []))->map(fn($path) => LaravelVsCode::relativePath($path))->toArray(),
+]);
 `;

--- a/src/templates/routes.ts
+++ b/src/templates/routes.ts
@@ -93,6 +93,5 @@ $routes = new class {
     }
 };
 
-
 echo $routes->all()->toJson();
 `;

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -12,6 +12,8 @@ $translator = new class
 
     public $emptyParams = [];
 
+    public $directoriesToWatch = [];
+
     public function all()
     {
         $final = [];
@@ -80,6 +82,10 @@ $translator = new class
 
         if (!is_dir($realPath)) {
             return [];
+        }
+
+        if (!LaravelVsCode::isVendor($realPath)) {
+            $this->directoriesToWatch[] = LaravelVsCode::relativePath($realPath);
         }
 
         return array_map(
@@ -342,5 +348,6 @@ echo json_encode([
     'paths' => array_keys($translator->paths),
     'values' => array_keys($translator->values),
     'params' => array_map(fn($p) => json_decode($p, true), array_keys($translator->paramResults)),
+    'to_watch' => $translator->directoriesToWatch,
 ]);
 `;


### PR DESCRIPTION
This PR aims to reduce the resources used by the extension by making the file watchers more specific. Specifically it:

- De-dupes file watchers watching the same pattern
- Ignores the `.git`, `vendor`, `node_module`, and `storage` directories which are large and can be resource intensive to watch
- Simplifies watching for `composer` updates