### PR TITLE
Support for locale parameter in translations

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -14,6 +14,8 @@ $translator = new class
 
     public $directoriesToWatch = [];
 
+    public $languages = [];
+
     public function all()
     {
         $final = [];
@@ -24,12 +26,20 @@ $translator = new class
                     $dotKey = $val["k"];
                     $final[$dotKey] ??= [];
 
+                    if (!in_array($val["la"], $this->languages)) {
+                      $this->languages[] = $val["la"];
+                    }
+
                     $final[$dotKey][$val["la"]] = $val["vs"];
                 }
             } else {
                 foreach ($value["vs"] as $v) {
                     $dotKey = "{$value["k"]}.{$v['k']}";
                     $final[$dotKey] ??= [];
+
+                    if (!in_array($$value["la"], $this->languages)) {
+                      $this->languages[] = $$value["la"];
+                    }
 
                     $final[$dotKey][$value["la"]] = $v['arr'];
                 }
@@ -345,6 +355,7 @@ $translator = new class
 echo json_encode([
     'default' => \Illuminate\Support\Facades\App::currentLocale(),
     'translations' => $translator->all(),
+    'languages' => $translator->languages,
     'paths' => array_keys($translator->paths),
     'values' => array_keys($translator->values),
     'params' => array_map(fn($p) => json_decode($p, true), array_keys($translator->paramResults)),

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -44,6 +44,7 @@ const paramArgIndexes = createIndexMapping([
             __: 1,
             trans: 1,
             "@lang": 1,
+            trans_choice: 2,
         },
     ],
     [
@@ -69,6 +70,7 @@ const localeArgIndexes = createIndexMapping([
             __: 2,
             trans: 2,
             "@lang": 2,
+            trans_choice: 3,
         },
     ],
     [

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -31,27 +31,22 @@ const toFind: FeatureTag = [
     },
 ];
 
-const getLang = (item: AutocompleteParsingResult.MethodCall): string | undefined => {
-    let lang = undefined;
+const getLangKey = (item: AutocompleteParsingResult.MethodCall): string | undefined => {
+    let langKey = undefined;
 
-    const children = item.arguments.children;
-    const locale = (children as AutocompleteParsingResult.Argument[]).find(
+    const locale = (item.arguments.children as AutocompleteParsingResult.Argument[]).find(
         (arg) => arg.name === "locale",
     );
 
     if (locale && locale.children.length) {
-        lang = (locale.children as AutocompleteParsingResult.StringValue[])[0].value;
+        langKey = (locale.children as AutocompleteParsingResult.StringValue[])[0].value;
     }
 
-    return lang;
+    return langKey;
 };
 
-const getTranslationItem = (translation: TranslationItem, lang?: string) => {
-    if (!lang) {
-        lang = getTranslations().items.default;
-    }
-
-    return translation[lang] ?? translation[Object.keys(translation)[0]];
+const getTranslationItem = (translation: TranslationItem, langKey?: string) => {
+    return translation[langKey ?? getTranslations().items.default] ?? translation[Object.keys(translation)[0]];
 };
 
 export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
@@ -73,7 +68,7 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
 
             const def = getTranslationItem(
                 translation, 
-                getLang(item as AutocompleteParsingResult.MethodCall)
+                getLangKey(item as AutocompleteParsingResult.MethodCall)
             );
 
             return new vscode.DocumentLink(

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -41,7 +41,8 @@ const getLang = (item: AutocompleteParsingResult.MethodCall): string | undefined
 };
 
 const getTranslationItemByLang = (translation: TranslationItem, lang?: string) => {
-    return translation[lang ?? getTranslations().items.default] ?? translation[Object.keys(translation)[0]];
+    return translation[lang ?? getTranslations().items.default] 
+        ?? translation[Object.keys(translation)[0]];
 };
 
 export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {

--- a/src/parser/AutocompleteResult.ts
+++ b/src/parser/AutocompleteResult.ts
@@ -117,6 +117,10 @@ export default class AutocompleteResult {
         return this.param()?.name ?? null;
     }
 
+    public isArgumentNamed(name: string) {
+        return this.argumentName() === name;
+    }
+
     public isParamIndex(index: number) {
         return this.paramIndex() === index;
     }

--- a/src/repositories/translations.ts
+++ b/src/repositories/translations.ts
@@ -17,6 +17,7 @@ interface TranslationGroupResult {
     translations: {
         [key: string]: TranslationItem;
     };
+    languages: string[];
 }
 
 interface TranslationGroupPhpResult {
@@ -30,6 +31,7 @@ interface TranslationGroupPhpResult {
     paths: string[];
     values: string[];
     to_watch: string[];
+    languages: string[];
 }
 
 let dirsToWatch: string[] | null = null;
@@ -63,6 +65,7 @@ const load = () => {
         return {
             default: res.default,
             translations: result,
+            languages: res.languages,
         };
     });
 };

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -125,3 +125,24 @@ export const waitForValue = <T>(
 
         checkForValue();
     });
+
+export const createIndexMapping = (
+    items: [string | string[], Record<string, number>][],
+) => {
+    const mapping: Record<string, Record<string, number>> = {};
+
+    items.forEach(([keys, value]) => {
+        keys = toArray(keys);
+
+        keys.forEach((key) => {
+            mapping[key] = value;
+        });
+    });
+
+    return {
+        mapping,
+        get(className: string | null, methodName: string | null) {
+            return mapping[className ?? ""][methodName ?? ""] ?? null;
+        },
+    };
+};

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -14,6 +14,8 @@ $translator = new class
 
     public $directoriesToWatch = [];
 
+    public $languages = [];
+
     public function all()
     {
         $final = [];
@@ -24,12 +26,20 @@ $translator = new class
                     $dotKey = $val["k"];
                     $final[$dotKey] ??= [];
 
+                    if (!in_array($val["la"], $this->languages)) {
+                      $this->languages[] = $val["la"];
+                    }
+
                     $final[$dotKey][$val["la"]] = $val["vs"];
                 }
             } else {
                 foreach ($value["vs"] as $v) {
                     $dotKey = "{$value["k"]}.{$v['k']}";
                     $final[$dotKey] ??= [];
+
+                    if (!in_array($$value["la"], $this->languages)) {
+                      $this->languages[] = $$value["la"];
+                    }
 
                     $final[$dotKey][$value["la"]] = $v['arr'];
                 }
@@ -345,6 +355,7 @@ $translator = new class
 echo json_encode([
     'default' => \\Illuminate\\Support\\Facades\\App::currentLocale(),
     'translations' => $translator->all(),
+    'languages' => $translator->languages,
     'paths' => array_keys($translator->paths),
     'values' => array_keys($translator->values),
     'params' => array_map(fn($p) => json_decode($p, true), array_keys($translator->paramResults)),


### PR DESCRIPTION
This PR adds support for locale parameter in translations, for example:

```php
__('validation.attributes.question', locale: 'pt_BR')
```

links to /lang/pt_BR/validation.php even though the default app.locale is en.

This code needs futher refactoring and testing.