### PR TITLE
Ability to quickly add `VITE_` env variables from existing

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,11 @@
                     "default": true,
                     "description": "Show popups for errors."
                 },
+                "Laravel.env.viteQuickFix": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable quickfix for adding VITE_ variables from regular env variables."
+                },
                 "Laravel.eloquent.generateDocBlocks": {
                     "type": "boolean",
                     "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import Registry from "./completion/Registry";
 import ValidationCompletion from "./completion/Validation";
 import { updateDiagnostics } from "./diagnostic/diagnostic";
 import { completionProvider as bladeComponentCompletion } from "./features/bladeComponent";
+import { viteEnvCodeActionProvider } from "./features/env";
 import { completionProvider as livewireComponentCompletion } from "./features/livewireComponent";
 import { hoverProviders } from "./hover/HoverProvider";
 import { linkProviders } from "./link/LinkProvider";
@@ -152,6 +153,16 @@ export function activate(context: vscode.ExtensionContext) {
             {
                 providedCodeActionKinds:
                     CodeActionProvider.providedCodeActionKinds,
+            },
+        ),
+        vscode.languages.registerCodeActionsProvider(
+            [
+                { scheme: "file", language: "plaintext" },
+                { scheme: "file", language: "ini" },
+            ],
+            viteEnvCodeActionProvider,
+            {
+                providedCodeActionKinds: [vscode.CodeActionKind.QuickFix],
             },
         ),
         vscode.commands.registerCommand("laravel.open", openFileCommand),

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -11,7 +11,8 @@ type ConfigKey =
     | "tests.suiteSuffix"
     | "showErrorPopups"
     | "blade.autoSpaceTags"
-    | "eloquent.generateDocBlocks";
+    | "eloquent.generateDocBlocks"
+    | "env.viteQuickFix";
 
 export const config = <T>(key: ConfigKey, fallback: T): T =>
     vscode.workspace.getConfiguration("Laravel").get<T>(key, fallback);


### PR DESCRIPTION
This PR adds a Quick Fix action that, when clicking on an existing `env` variable, can quickly add it as a `VITE_` variable in your file. Also works when selecting multiple lines. Easily disabled via the `Env Vite Quick Fix` config if the behavior isn't desired.

![CleanShot 2025-03-13 at 12 58 34](https://github.com/user-attachments/assets/fba954f8-b01d-4959-8c03-72558830b2b9)
