### PR TITLE
Better resolution for `$request->user()`, `auth()->user()`, and `Auth::user()`

### DIFF
--- a/php-templates/auth.php
+++ b/php-templates/auth.php
@@ -13,6 +13,36 @@ $modelPolicies = collect(get_declared_classes())
     ])
     ->filter(fn($policy) => $policy !== null);
 
+function vsCodeGetAuthenticatable() {
+    try {
+        $guard = auth()->guard();
+
+        $reflection = new \ReflectionClass($guard);
+
+        if (!$reflection->hasProperty("provider")) {
+            return null;
+        }
+
+        $property = $reflection->getProperty("provider");
+        $provider = $property->getValue($guard);
+
+        if ($provider instanceof \Illuminate\Auth\EloquentUserProvider) {
+            $providerReflection = new \ReflectionClass($provider);
+            $modelProperty = $providerReflection->getProperty("model");
+
+            return str($modelProperty->getValue($provider))->prepend("\\")->toString();
+        }
+
+        if ($provider instanceof \Illuminate\Auth\DatabaseUserProvider) {
+            return str(\Illuminate\Auth\GenericUser::class)->prepend("\\")->toString();
+        }
+    } catch (\Exception | \Throwable $e) {
+        return null;
+    }
+
+    return null;
+}
+
 function vsCodeGetPolicyInfo($policy, $model)
 {
     $methods = (new ReflectionClass($policy))->getMethods();
@@ -26,38 +56,40 @@ function vsCodeGetPolicyInfo($policy, $model)
     ])->filter(fn($ability) => !in_array($ability['key'], ['allow', 'deny']));
 }
 
-echo collect(\Illuminate\Support\Facades\Gate::abilities())
-    ->map(function ($policy, $key) {
-        $reflection = new \ReflectionFunction($policy);
-        $policyClass = null;
-        $closureThis = $reflection->getClosureThis();
+echo json_encode([
+    'authenticatable' => vsCodeGetAuthenticatable(),
+    'policies' => collect(\Illuminate\Support\Facades\Gate::abilities())
+                    ->map(function ($policy, $key) {
+                        $reflection = new \ReflectionFunction($policy);
+                        $policyClass = null;
+                        $closureThis = $reflection->getClosureThis();
 
-        if ($closureThis !== null) {
-            if (get_class($closureThis) === \Illuminate\Auth\Access\Gate::class) {
-                $vars = $reflection->getClosureUsedVariables();
+                        if ($closureThis !== null) {
+                            if (get_class($closureThis) === \Illuminate\Auth\Access\Gate::class) {
+                                $vars = $reflection->getClosureUsedVariables();
 
-                if (isset($vars['callback'])) {
-                    [$policyClass, $method] = explode('@', $vars['callback']);
+                                if (isset($vars['callback'])) {
+                                    [$policyClass, $method] = explode('@', $vars['callback']);
 
-                    $reflection = new \ReflectionMethod($policyClass, $method);
-                }
-            }
-        }
+                                    $reflection = new \ReflectionMethod($policyClass, $method);
+                                }
+                            }
+                        }
 
-        return [
-            'key' => $key,
-            'uri' => $reflection->getFileName(),
-            'policy' => $policyClass,
-            'line' => $reflection->getStartLine(),
-        ];
-    })
-    ->merge(
-        collect(\Illuminate\Support\Facades\Gate::policies())->flatMap(fn($policy, $model) => vsCodeGetPolicyInfo($policy, $model)),
-    )
-    ->merge(
-        $modelPolicies->flatMap(fn($policy, $model) => vsCodeGetPolicyInfo($policy, $model)),
-    )
-    ->values()
-    ->groupBy('key')
-    ->map(fn($item) => $item->map(fn($i) => \Illuminate\Support\Arr::except($i, 'key')))
-    ->toJson();
+                        return [
+                            'key' => $key,
+                            'uri' => $reflection->getFileName(),
+                            'policy' => $policyClass,
+                            'line' => $reflection->getStartLine(),
+                        ];
+                    })
+                    ->merge(
+                        collect(\Illuminate\Support\Facades\Gate::policies())->flatMap(fn($policy, $model) => vsCodeGetPolicyInfo($policy, $model)),
+                    )
+                    ->merge(
+                        $modelPolicies->flatMap(fn($policy, $model) => vsCodeGetPolicyInfo($policy, $model)),
+                    )
+                    ->values()
+                    ->groupBy('key')
+                    ->map(fn($item) => $item->map(fn($i) => \Illuminate\Support\Arr::except($i, 'key'))),
+]);

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -26,7 +26,7 @@ const toFind: FeatureTag = [
             "check",
             "any",
             "authorize",
-            "inspect",            
+            "inspect",
         ],
         argumentIndex: 0,
     },
@@ -106,7 +106,7 @@ const analyzeParam = (
     }
 
     const policies = values
-        .map((value) => getPolicies().items[value.value])
+        .map((value) => getPolicies().items.policies[value.value])
         .flat();
 
     if (["has"].includes(item.methodName)) {
@@ -301,26 +301,28 @@ export const completionProvider: CompletionProvider = {
             return [];
         }
 
-        return Object.entries(getPolicies().items).map(([key, value]) => {
-            let completeItem = new vscode.CompletionItem(
-                key,
-                vscode.CompletionItemKind.Value,
-            );
+        return Object.entries(getPolicies().items.policies).map(
+            ([key, value]) => {
+                let completeItem = new vscode.CompletionItem(
+                    key,
+                    vscode.CompletionItemKind.Value,
+                );
 
-            completeItem.range = document.getWordRangeAtPosition(
-                position,
-                wordMatchRegex,
-            );
+                completeItem.range = document.getWordRangeAtPosition(
+                    position,
+                    wordMatchRegex,
+                );
 
-            const policyClasses = value
-                .map((item) => item.policy)
-                .filter(String);
+                const policyClasses = value
+                    .map((item) => item.policy)
+                    .filter(String);
 
-            if (policyClasses.length > 0) {
-                completeItem.detail = policyClasses.join("\n\n");
-            }
+                if (policyClasses.length > 0) {
+                    completeItem.detail = policyClasses.join("\n\n");
+                }
 
-            return completeItem;
-        });
+                return completeItem;
+            },
+        );
     },
 };

--- a/src/repositories/auth.ts
+++ b/src/repositories/auth.ts
@@ -53,6 +53,21 @@ interface Request
     public function user();
 }`,
         },
+        {
+            file: "_facade.php",
+            content: `
+<?php
+
+namespace Illuminate\\Support\\Facades;
+
+interface Auth
+{
+    /**
+     * @return ${authenticatable}|null
+     */
+    public function user();
+}`,
+        },
     ];
 
     blocks.forEach((block) => {

--- a/src/repositories/auth.ts
+++ b/src/repositories/auth.ts
@@ -50,7 +50,7 @@ interface Request
     /**
      * @return ${authenticatable}|null
      */
-    public function user();
+    public function user($guard = null);
 }`,
         },
         {
@@ -63,9 +63,39 @@ namespace Illuminate\\Support\\Facades;
 interface Auth
 {
     /**
+     * @return ${authenticatable}|false
+     */
+    public static function loginUsingId(mixed $id, bool $remember = false);
+
+    /**
+     * @return ${authenticatable}|false
+     */
+    public static function onceUsingId(mixed $id);
+
+    /**
      * @return ${authenticatable}|null
      */
-    public function user();
+    public static function getUser();
+
+    /**
+     * @return ${authenticatable}
+     */
+    public static function authenticate();
+
+    /**
+     * @return ${authenticatable}|null
+     */
+    public static function user();
+
+    /**
+     * @return ${authenticatable}|null
+     */
+    public static function logoutOtherDevices(string $password);
+
+    /**
+     * @return ${authenticatable}
+     */
+    public static function getLastAttempted();
 }`,
         },
     ];

--- a/src/repositories/translations.ts
+++ b/src/repositories/translations.ts
@@ -83,5 +83,6 @@ export const getTranslations = repository<TranslationGroupResult>({
     itemsDefault: {
         default: "",
         translations: {},
+        languages: [],
     },
 });


### PR DESCRIPTION
In most cases, this PR should add better IDE hints for the underlying resolved `\Illuminate\Contracts\Auth\Authenticatable`. 

It's a step in the right direction, but it's not a fully formed solution just yet.