### PR TITLE
Support for autocompletion rules in FormRequest

### DIFF
--- a/src/completion/Registry.ts
+++ b/src/completion/Registry.ts
@@ -82,6 +82,22 @@ export default class Registry implements vscode.CompletionItemProvider {
             );
         };
 
+        const hasClassExtends = (classExtends: FeatureTagParam["classExtends"]) => {
+            if (typeof classExtends === "undefined" || classExtends === null) {
+                return true;
+            }
+
+            return parseResult.isClassDefinitionExtends(classExtends);
+        };
+
+        const hasMethodDefinition = (methodDefinitions: FeatureTagParam["methodDefinition"]) => {
+            if (typeof methodDefinitions === "undefined" || methodDefinitions === null) {
+                return true;
+            }
+
+            return parseResult.isMethodDefinition(methodDefinitions);
+        };
+
         const isArgumentIndex = (
             argumentIndex: number | number[] | undefined,
         ) => {
@@ -118,7 +134,9 @@ export default class Registry implements vscode.CompletionItemProvider {
                         hasClass(tag.class) &&
                         hasFunc(tag.method) &&
                         isArgumentIndex(tag.argumentIndex) &&
-                        isNamedArg(tag.argumentName),
+                        isNamedArg(tag.argumentName) &&
+                        hasClassExtends(tag.classExtends) &&
+                        hasMethodDefinition(tag.methodDefinition),
                 );
             }) || null
         );

--- a/src/completion/Validation.ts
+++ b/src/completion/Validation.ts
@@ -123,9 +123,12 @@ export default class Validation implements CompletionProvider {
                 argumentIndex: 0,
             },
             {
-                classExtends: "Illuminate\\Foundation\\Http\\FormRequest",
+                classExtends: [
+                    "Illuminate\\Foundation\\Http\\FormRequest",
+                    "Livewire\\Form",
+                ],
                 methodDefinition: "rules",
-            },
+            },            
         ];
     }
 
@@ -144,9 +147,7 @@ export default class Validation implements CompletionProvider {
             return this.validatorValidation(document, position, result) || [];
         }
 
-        // TODO: Deal with FormRequest@rules method
-
-        return [];
+        return this.handleFormRequestRulesMethod(document, position, result);
     }
 
     private handleValidateMethod(
@@ -180,6 +181,19 @@ export default class Validation implements CompletionProvider {
         ) {
             return this.getRules(document, position);
         }
+    }
+
+    private handleFormRequestRulesMethod(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        result: AutocompleteResult,
+    ): vscode.CompletionItem[] {
+        if (result.fillingInArrayValue()) {
+            // We only fill in values for the validate method, abort
+            return [];
+        }
+
+        return this.getRules(document, position);
     }
 
     private getRules(

--- a/src/completion/Validation.ts
+++ b/src/completion/Validation.ts
@@ -188,8 +188,7 @@ export default class Validation implements CompletionProvider {
         position: vscode.Position,
         result: AutocompleteResult,
     ): vscode.CompletionItem[] {
-        if (result.fillingInArrayValue()) {
-            // We only fill in values for the validate method, abort
+        if (result.fillingInRulesArrayKey()) {
             return [];
         }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -51,7 +51,7 @@ interface FeatureTagParam {
     argumentName?: string | string[];
     classDefinition?: string;
     methodDefinition?: string;
-    classExtends?: string;
+    classExtends?: string | string[];
     classImplements?: string;
     argumentIndex?: number | number[];
 }

--- a/src/parser/AutocompleteResult.ts
+++ b/src/parser/AutocompleteResult.ts
@@ -33,6 +33,9 @@ export default class AutocompleteResult {
     }
 
     public fillingInRulesArrayKey(): boolean {
+        // I'm not sure if this is enough to determine 
+        // if we're filling in a rules array key but I don't
+        // have better idea at this moment :/
         return this.result.parent?.type !== "array_item";
     }
 

--- a/src/parser/AutocompleteResult.ts
+++ b/src/parser/AutocompleteResult.ts
@@ -32,6 +32,10 @@ export default class AutocompleteResult {
         );
     }
 
+    public fillingInRulesArrayKey(): boolean {
+        return this.result.parent?.type !== "array_item";
+    }
+
     public fillingInArrayKey(): boolean {
         return this.param()?.autocompletingKey ?? false;
     }

--- a/src/parser/AutocompleteResult.ts
+++ b/src/parser/AutocompleteResult.ts
@@ -65,6 +65,46 @@ export default class AutocompleteResult {
         );
     }
 
+    public isClassDefinitionExtends(classNames: string | string[]) {
+        classNames = Array.isArray(classNames) ? classNames : [classNames];
+
+        let check = false;
+
+        this.loop((context) => {
+            if (classNames.some((className: string) => {
+                return (context as AutocompleteParsingResult.ClassDefinition).extends === className;
+            })) {
+                check = true;
+
+                return false;
+            }
+
+            return true;
+        });
+
+        return check;
+    }
+
+    public isMethodDefinition(methodNames: string | string[]) {
+        methodNames = Array.isArray(methodNames) ? methodNames : [methodNames];
+
+        let check = false;
+
+        this.loop((context) => {
+            if (methodNames.some((methodName: string) => {
+                return (context as AutocompleteParsingResult.MethodDefinition).methodName === methodName;
+            })) {
+                check = true;
+
+                return false;
+            }
+
+            return true;
+        });
+
+        return check;
+    }
+
     public func() {
         // @ts-ignore
         return this.result.methodName ?? null;


### PR DESCRIPTION
This PR adds autocompletion rules names in FormRequest::rules method. It works for Livewire Forms as well.

![rules](https://github.com/user-attachments/assets/0408a86a-fc9f-4026-8f1f-a5e87a55fd8f)

This PR depends on https://github.com/laravel/vs-code-php-parser-cli/pull/16 and requires much more testing.