### PR TITLE
Fix Cannot access offset of type array on array

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -298,6 +298,10 @@ $translator = new class
             [$json, $lines] = $this->linesFromJsonFile($file);
 
             foreach ($json as $key => $value) {
+                if (!array_key_exists($key, $lines) || is_array($value)) {
+                    continue;
+                }
+
                 yield [
                     "k" => $key,
                     "la" => $lang,

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -298,6 +298,10 @@ $translator = new class
             [$json, $lines] = $this->linesFromJsonFile($file);
 
             foreach ($json as $key => $value) {
+                if (!array_key_exists($key, $lines) || is_array($value)) {
+                    continue;
+                }
+
                 yield [
                     "k" => $key,
                     "la" => $lang,


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/340, https://github.com/laravel/vs-code-extension/issues/272, https://github.com/laravel/vs-code-extension/issues/262, https://github.com/laravel/vs-code-extension/issues/380

If someone has an array in a .json translation file, something like this:

```json
{
    "This is a correct translation": "To jest prawidłowe tłumaczenie",
    "This is not a correct translation": {
        "I don't know why people": "Nie wiem dlaczego ludzie",
        "do that": "robią coś takiego"
    }
}
```

then the extension throws an error:

```
2025-03-18 12:47:03.650 [error] Translations

Error: __VSCODE_LARAVEL_START_OUTPUT__
   TypeError 

  Cannot access offset of type array on array

  at vendor/_laravel_ide/discover-13e3a4436281ac748c1072dc641041d7.php:302
    298▕     }
    299▕ 
    300▕     protected function getValueIndex($value)
    301▕     {
  ➜ 302▕         $index = $this->values[$value] ?? null;
    303▕ 
    304▕         if ($index !== null) {
    305▕             return $index;
    306▕         }
```

This PR adds the extra check to verify if the translation is an array.
