### PR TITLE
Support for Laravel 12 scope attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-laravel",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-laravel",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "dependencies": {
                 "axios": "^1.8.2",
                 "extract-zip": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "laravel",
     "displayName": "Laravel",
     "description": "Official VS Code extension for Laravel",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "engines": {
         "vscode": "^1.89.0"
     },

--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -155,7 +155,7 @@ $models = new class($factory) {
             ->toArray();
 
         $data['scopes'] = collect($reflection->getMethods())
-            ->filter(fn($method) => $method->isPublic() && !$method->isStatic() && str_starts_with($method->name, 'scope'))
+            ->filter(fn($method) =>!$method->isStatic() && ($method->getAttributes(\Illuminate\Database\Eloquent\Attributes\Scope::class) || ($method->isPublic() && str_starts_with($method->name, 'scope'))))
             ->map(fn($method) => str($method->name)->replace('scope', '')->lcfirst()->toString())
             ->values()
             ->toArray();
@@ -175,8 +175,8 @@ $builder = new class($docblocks) {
     {
         $reflection = new \ReflectionClass(\Illuminate\Database\Query\Builder::class);
 
-        return collect($reflection->getMethods(\ReflectionMethod::IS_PUBLIC))
-            ->filter(fn(ReflectionMethod $method) => !str_starts_with($method->getName(), "__"))
+        return collect($reflection->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED))
+            ->filter(fn(ReflectionMethod $method) => !str_starts_with($method->getName(), "__") || (!$method->isPublic() && empty($method->getAttributes(\Illuminate\Database\Eloquent\Attributes\Scope::class))))
             ->map(fn(\ReflectionMethod $method) => $this->getMethodInfo($method))
             ->filter()
             ->values();

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -155,7 +155,7 @@ $models = new class($factory) {
             ->toArray();
 
         $data['scopes'] = collect($reflection->getMethods())
-            ->filter(fn($method) => $method->isPublic() && !$method->isStatic() && str_starts_with($method->name, 'scope'))
+            ->filter(fn($method) =>!$method->isStatic() && ($method->getAttributes(\\Illuminate\\Database\\Eloquent\\Attributes\\Scope::class) || ($method->isPublic() && str_starts_with($method->name, 'scope'))))
             ->map(fn($method) => str($method->name)->replace('scope', '')->lcfirst()->toString())
             ->values()
             ->toArray();
@@ -175,8 +175,8 @@ $builder = new class($docblocks) {
     {
         $reflection = new \\ReflectionClass(\\Illuminate\\Database\\Query\\Builder::class);
 
-        return collect($reflection->getMethods(\\ReflectionMethod::IS_PUBLIC))
-            ->filter(fn(ReflectionMethod $method) => !str_starts_with($method->getName(), "__"))
+        return collect($reflection->getMethods(\\ReflectionMethod::IS_PUBLIC | \\ReflectionMethod::IS_PROTECTED))
+            ->filter(fn(ReflectionMethod $method) => !str_starts_with($method->getName(), "__") || (!$method->isPublic() && empty($method->getAttributes(\\Illuminate\\Database\\Eloquent\\Attributes\\Scope::class))))
             ->map(fn(\\ReflectionMethod $method) => $this->getMethodInfo($method))
             ->filter()
             ->values();


### PR DESCRIPTION
Adds support for model scopes using `#[Scope]` attribute:

https://laravel.com/docs/12.x/eloquent#local-scopes