### PR TITLE
Fix a bug with overrides vendor blade components

### DIFF
--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -209,21 +209,22 @@ $components = new class {
         $views = $finder->getHints();
 
         foreach ($views as $key => $paths) {
-            // First is always optional override in the resources/views folder
-            $path = $paths[0] . '/components';
+            foreach ($paths as $path) {
+                $path .= '/components';
 
-            if (!is_dir($path)) {
-                continue;
+                if (!is_dir($path)) {
+                    continue;
+                }
+
+                array_push(
+                    $components,
+                    ...$this->findFiles(
+                        $path,
+                        'blade.php',
+                        fn (\Illuminate\Support\Stringable $k) => $k->kebab()->prepend($key.'::'),
+                    )
+                );
             }
-
-            array_push(
-                $components,
-                ...$this->findFiles(
-                    $path,
-                    'blade.php',
-                    fn (\Illuminate\Support\Stringable $k) => $k->kebab()->prepend($key.'::'),
-                )
-            );
         }
 
         return $components;

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -209,21 +209,22 @@ $components = new class {
         $views = $finder->getHints();
 
         foreach ($views as $key => $paths) {
-            // First is always optional override in the resources/views folder
-            $path = $paths[0] . '/components';
+            foreach ($paths as $path) {
+                $path .= '/components';
 
-            if (!is_dir($path)) {
-                continue;
+                if (!is_dir($path)) {
+                    continue;
+                }
+
+                array_push(
+                    $components,
+                    ...$this->findFiles(
+                        $path,
+                        'blade.php',
+                        fn (\\Illuminate\\Support\\Stringable $k) => $k->kebab()->prepend($key.'::'),
+                    )
+                );
             }
-
-            array_push(
-                $components,
-                ...$this->findFiles(
-                    $path,
-                    'blade.php',
-                    fn (\\Illuminate\\Support\\Stringable $k) => $k->kebab()->prepend($key.'::'),
-                )
-            );
         }
 
         return $components;


### PR DESCRIPTION
I made a mistake with my previous PR https://github.com/laravel/vs-code-extension/pull/310

If any component has the override in the resources/views folder, then the extension only reads files from this location while skipping the rest of the files from the vendor location.

This PR fixes this issue.

Before:

![before](https://github.com/user-attachments/assets/752e4975-38b6-47fb-96b9-b7b27ae925e5)

After:

![after](https://github.com/user-attachments/assets/c3e1207c-9b6f-49db-904d-e2379e91efce)
