### PR TITLE
Add component properties from the @props directive to the repository

### DIFF
--- a/generate-templates.php
+++ b/generate-templates.php
@@ -6,7 +6,7 @@ foreach ($templates as $template) {
     $content = file_get_contents($template);
 
     $content = str_replace('\\', '\\\\', $content);
-    $content = str_replace('<?php', '', $content);
+    $content = preg_replace('/^<\?php/', '', $content);
     $content = implode("\n", [
         "// This file was generated from {$template}, do not edit directly",
         'export default `',

--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -102,8 +102,8 @@ $components = new class {
                         array_push($this->props, match (true) {
                             $item->value instanceof \PhpParser\Node\Scalar\String_ => [
                                 'name' => \Illuminate\Support\Str::kebab($item->key?->value ?? $item->value->value),
-                                'type' => 'string',
-                                'hasDefault' => $item->key ?? false, 
+                                'type' => $item->key ? 'string' : 'undefined',
+                                'hasDefault' => $item->key ? true : false, 
                                 'default' => $item->key ? $item->value->value : null,
                             ],
                             $item->value instanceof \PhpParser\Node\Expr\ConstFetch => [

--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -32,11 +32,135 @@ $components = new class {
         ];
     }
 
+    private function runConcurrency(array $items, \Closure $callback, int $concurrency = 4): array
+    {
+        $tasks = collect($items)
+            ->split($concurrency)
+            ->map(fn (\Illuminate\Support\Collection $chunk) => fn (): array => $callback($chunk))
+            ->toArray();
+
+        $results = \Illuminate\Support\Facades\Concurrency::driver(match (true) {
+            \Composer\InstalledVersions::isInstalled('spatie/fork') => 'fork',
+            default => 'sync',
+        })->run($tasks);
+
+        return array_merge(...$results);
+    }
+
+    private function getComponentPropsFromDirective(string $path): array
+    {
+        if (!\Illuminate\Support\Facades\File::exists($path)) {
+            return [];
+        }
+
+        $contents = \Illuminate\Support\Facades\File::get($path);
+
+        $propsAsString = str($contents)->match('/\@props\((.*?)\)/s')->toString();
+
+        if (empty($propsAsString)) {
+            return [];
+        }
+
+        $parser = (new \PhpParser\ParserFactory)->createForNewestSupportedVersion();
+
+        try {
+            $ast = $parser->parse("<?php return {$propsAsString};");
+        } catch (\Throwable $e) {
+            return [];
+        }
+
+        $traverser = new \PhpParser\NodeTraverser();
+        $visitor = new class extends \PhpParser\NodeVisitorAbstract {
+            public array $props = [];
+
+            /**
+             * @param array<int, \PhpParser\Node\ArrayItem> $items
+             */
+            private function getItemsAsArray(array $items): array
+            {
+                $array = [];
+
+                foreach ($items as $item) {
+                    $value = $item->value->value;
+
+                    if ($item->value instanceof \PhpParser\Node\Expr\Array_) {
+                        $value = $this->getItemsAsArray($item->value->items);
+                    }
+
+                    $array[$item->key?->value] = $value;
+                }
+
+                return $array;
+            }
+
+            public function enterNode(\PhpParser\Node $node) {
+                if (
+                    $node instanceof \PhpParser\Node\Stmt\Return_
+                    && $node->expr instanceof \PhpParser\Node\Expr\Array_
+                ) {
+                    foreach ($node->expr->items as $item) {
+                        array_push($this->props, match (true) {
+                            $item->value instanceof \PhpParser\Node\Scalar\String_ => [
+                                'name' => \Illuminate\Support\Str::kebab($item->key?->value ?? $item->value->value),
+                                'type' => 'string',
+                                'hasDefault' => $item->key ?? false, 
+                                'default' => $item->key ? $item->value->value : null,
+                            ],
+                            $item->value instanceof \PhpParser\Node\Expr\ConstFetch => [
+                                'name' => \Illuminate\Support\Str::kebab($item->key->value),
+                                'type' => $item->value->name->toString() !== "null" ? 'boolean' : null,
+                                'hasDefault' => true,
+                                'default' => $item->value->name->toString(),
+                            ],
+                            $item->value instanceof \PhpParser\Node\Scalar\Int_ => [
+                                'name' => \Illuminate\Support\Str::kebab($item->key->value),
+                                'type' => 'integer',
+                                'hasDefault' => true,
+                                'default' => $item->value->value,
+                            ],
+                            $item->value instanceof \PhpParser\Node\Expr\Array_ => [
+                                'name' => \Illuminate\Support\Str::kebab($item->key->value),
+                                'type' => 'array',
+                                'hasDefault' => true,
+                                'default' => $this->getItemsAsArray($item->value->items),
+                            ],
+                            default => null
+                        });
+                    }
+                }
+            }
+        };
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return array_filter($visitor->props);
+    }
+
+    private function mapComponentProps(\Illuminate\Support\Collection $files): array
+    {
+        return $files->map(function (array $item): array {
+            $props = $this->getComponentPropsFromDirective($item['path']);
+
+            if ($props !== []) {
+                $item = [
+                    ...$item,
+                    'props' => $props,
+                ];
+            }
+
+            return $item;
+        })->all();
+    }
+
     protected function getStandardViews()
     {
         $path = resource_path('views/components');
 
-        return $this->findFiles($path, 'blade.php');
+        $files = $this->findFiles($path, 'blade.php');
+
+        return \Composer\InstalledVersions::isInstalled('nikic/php-parser')
+            ? $this->runConcurrency($files, fn (\Illuminate\Support\Collection $files): array => $this->mapComponentProps($files))
+            : $files;
     }
 
     protected function findFiles($path, $extension, $keyCallback = null)
@@ -110,6 +234,9 @@ $components = new class {
                 ->map(fn($p) => [
                     'name' => \Illuminate\Support\Str::kebab($p->getName()),
                     'type' => (string) ($p->getType() ?? 'mixed'),
+                    // We need to add hasDefault, because null can be also a default value,
+                    // it can't be a flag of no default
+                    'hasDefault' => $p->hasDefaultValue(), 
                     'default' => $p->getDefaultValue() ?? $parameters[$p->getName()] ?? null,
                 ]);
 
@@ -226,7 +353,9 @@ $components = new class {
             );
         }
 
-        return $components;
+        return \Composer\InstalledVersions::isInstalled('nikic/php-parser')
+            ? $this->runConcurrency($components, fn (\Illuminate\Support\Collection $files): array => $this->mapComponentProps($files))
+            : $components;
     }
 
     protected function handleIndexComponents($str)

--- a/src/features/bladeComponent.ts
+++ b/src/features/bladeComponent.ts
@@ -1,6 +1,7 @@
 import { getBladeComponents } from "@src/repositories/bladeComponents";
 import { config } from "@src/support/config";
 import { projectPath } from "@src/support/project";
+import { defaultToString } from "@src/support/util";
 import * as vscode from "vscode";
 import { HoverProvider, LinkProvider } from "..";
 
@@ -131,7 +132,7 @@ export const hoverProvider: HoverProvider = (
                 [
                     "`" + prop.type + "` ",
                     "`" + prop.name + "`",
-                    prop.default ? ` = ${prop.default}` : "",
+                    prop.hasDefault ? ` = ${defaultToString(prop.default)}` : "",
                 ].join(""),
             ),
         );

--- a/src/repositories/bladeComponents.ts
+++ b/src/repositories/bladeComponents.ts
@@ -10,6 +10,7 @@ export interface BladeComponents {
             props: {
                 name: string;
                 type: string;
+                hasDefault: boolean;
                 default: string | null;
             }[];
         };

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -146,3 +146,24 @@ export const createIndexMapping = (
         },
     };
 };
+
+export const defaultToString = (value: any): string => {
+    switch (typeof value) {
+        case "object":
+            if (value === null) {
+                return "null";
+            }
+
+            const json: string = JSON.stringify(value, null, 2);
+
+            if (json.length > 1000) {
+                return "object";
+            }
+
+            return json;
+        case "function":
+            return "function";
+        default:
+            return value.toString();
+    }
+};

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -102,8 +102,8 @@ $components = new class {
                         array_push($this->props, match (true) {
                             $item->value instanceof \\PhpParser\\Node\\Scalar\\String_ => [
                                 'name' => \\Illuminate\\Support\\Str::kebab($item->key?->value ?? $item->value->value),
-                                'type' => 'string',
-                                'hasDefault' => $item->key ?? false, 
+                                'type' => $item->key ? 'string' : 'undefined',
+                                'hasDefault' => $item->key ? true : false, 
                                 'default' => $item->key ? $item->value->value : null,
                             ],
                             $item->value instanceof \\PhpParser\\Node\\Expr\\ConstFetch => [
@@ -158,7 +158,9 @@ $components = new class {
 
         $files = $this->findFiles($path, 'blade.php');
 
-        return $this->runConcurrency($files, fn (\\Illuminate\\Support\\Collection $files): array => $this->mapComponentProps($files));
+        return \\Composer\\InstalledVersions::isInstalled('nikic/php-parser')
+            ? $this->runConcurrency($files, fn (\\Illuminate\\Support\\Collection $files): array => $this->mapComponentProps($files))
+            : $files;
     }
 
     protected function findFiles($path, $extension, $keyCallback = null)
@@ -351,7 +353,9 @@ $components = new class {
             );
         }
 
-        return $this->runConcurrency($components, fn (\\Illuminate\\Support\\Collection $files): array => $this->mapComponentProps($files));;
+        return \\Composer\\InstalledVersions::isInstalled('nikic/php-parser')
+            ? $this->runConcurrency($components, fn (\\Illuminate\\Support\\Collection $files): array => $this->mapComponentProps($files))
+            : $components;
     }
 
     protected function handleIndexComponents($str)


### PR DESCRIPTION
This PR adds searching for component properties from the `@props` directive.

For example, the component:

![component](https://github.com/user-attachments/assets/3b43b08c-9d52-4843-9753-3ec19625807b)

And its properties in the hover:

![hover](https://github.com/user-attachments/assets/801811fe-93dc-44ab-8f1e-7d82163f8821)

The feature works only if the `nikic/php-parser` is installed in the application. Otherwise, skips the property search.

If the `spatie/fork` is installed, then the search is performed in parallel (by [Laravel Concurrency](https://laravel.com/docs/12.x/concurrency)). Otherwise, the search is synchronous. BTW, I don't know if the performance will be enough with a large number of components :/ It needs more testing.

If PR is accepted, this feature will be available for use in attributes autocompletion https://github.com/laravel/vs-code-extension/pull/366 

For now, draft, because there is much to do.