### PR TITLE
Fix False positive "Translation not found" with partial string in Laravel JSON translation

### DIFF
--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -101,6 +101,10 @@ const getLang = (
         : undefined;
 };
 
+const getTranslationItem = (match: string): TranslationItem | undefined => {
+    return getTranslations().items.translations[match.replaceAll('\\', '')];
+};
+
 const getTranslationItemByLang = (
     translation: TranslationItem,
     lang?: string,
@@ -121,8 +125,7 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
                 return null;
             }
 
-            const translation =
-                getTranslations().items.translations[param.value];
+            const translation = getTranslationItem(param.value);
 
             if (!translation) {
                 return null;
@@ -148,7 +151,7 @@ export const hoverProvider: HoverProvider = (
     pos: vscode.Position,
 ): vscode.ProviderResult<vscode.Hover> => {
     return findHoverMatchesInDoc(doc, pos, toFind, getTranslations, (match) => {
-        const item = getTranslations().items.translations[match];
+        const item = getTranslationItem(match);
 
         if (!item) {
             return null;
@@ -184,7 +187,7 @@ export const diagnosticProvider = (
                 return null;
             }
 
-            const item = getTranslations().items.translations[param.value];
+            const item = getTranslationItem(param.value);
 
             if (item) {
                 return null;

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -1,6 +1,7 @@
 import { notFound } from "@src/diagnostic";
 import AutocompleteResult from "@src/parser/AutocompleteResult";
 import {
+    getTranslationItemByName,
     getTranslations,
     TranslationItem,
 } from "@src/repositories/translations";
@@ -101,10 +102,6 @@ const getLang = (
         : undefined;
 };
 
-const getTranslationItem = (match: string): TranslationItem | undefined => {
-    return getTranslations().items.translations[match.replaceAll('\\', '')];
-};
-
 const getTranslationItemByLang = (
     translation: TranslationItem,
     lang?: string,
@@ -125,7 +122,7 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
                 return null;
             }
 
-            const translation = getTranslationItem(param.value);
+            const translation = getTranslationItemByName(param.value);
 
             if (!translation) {
                 return null;
@@ -151,7 +148,7 @@ export const hoverProvider: HoverProvider = (
     pos: vscode.Position,
 ): vscode.ProviderResult<vscode.Hover> => {
     return findHoverMatchesInDoc(doc, pos, toFind, getTranslations, (match) => {
-        const item = getTranslationItem(match);
+        const item = getTranslationItemByName(match);
 
         if (!item) {
             return null;
@@ -187,7 +184,7 @@ export const diagnosticProvider = (
                 return null;
             }
 
-            const item = getTranslationItem(param.value);
+            const item = getTranslationItemByName(param.value);
 
             if (item) {
                 return null;

--- a/src/features/translation.ts
+++ b/src/features/translation.ts
@@ -252,6 +252,15 @@ export const completionProvider = {
             getTranslations().items.translations,
         ).length;
 
+        const precedingCharacter = document.getText(
+            new vscode.Range(
+                position.line,
+                position.character - 1,
+                position.line,
+                position.character,
+            ),
+        );
+
         return Object.entries(getTranslations().items.translations).map(
             ([key, translations]) => {
                 let completionItem = new vscode.CompletionItem(
@@ -263,6 +272,12 @@ export const completionProvider = {
                     position,
                     wordMatchRegex,
                 );
+
+                if (precedingCharacter === "'") {
+                    completionItem.insertText = key.replaceAll("'", "\\'");
+                } else if (precedingCharacter === '"') {
+                    completionItem.insertText = key.replaceAll('"', '\\"');
+                }
 
                 if (totalTranslationItems < 200) {
                     // This will bomb if we have too many translations,

--- a/src/repositories/translations.ts
+++ b/src/repositories/translations.ts
@@ -70,6 +70,10 @@ const load = () => {
     });
 };
 
+export const getTranslationItemByName = (match: string): TranslationItem | undefined => {
+    return getTranslations().items.translations[match.replaceAll('\\', '')];
+};
+
 export const getTranslations = repository<TranslationGroupResult>({
     load,
     pattern: () =>

--- a/src/support/doc.ts
+++ b/src/support/doc.ts
@@ -69,7 +69,7 @@ export const findHoverMatchesInDoc = (
 ): ProviderResult<Hover> => {
     const linkRange = doc.getWordRangeAtPosition(
         pos,
-        new RegExp(/(['"])(.*?)\1/),
+        new RegExp(/(?<!\\)(['"])(.*?)(?<!\\)\1/),
     );
 
     if (!linkRange) {


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/374

Before:

![before](https://github.com/user-attachments/assets/0ec19da7-62e8-4554-bb66-fdfaab4f96c6)

After:

![after](https://github.com/user-attachments/assets/ac58614b-8d5d-4ad1-b5e3-badf83c4daf4)
