### PR TITLE
Fix a bug with enums in config files

### DIFF
--- a/php-templates/configs.php
+++ b/php-templates/configs.php
@@ -117,6 +117,10 @@ function vsCodeGetConfigValue($value, $key, $configPaths) {
       }
     }
 
+    if (is_object($value)) {
+      $value = get_class($value);
+    }
+
     return [
       "name" => $key,
       "value" => $value,

--- a/src/templates/configs.ts
+++ b/src/templates/configs.ts
@@ -117,6 +117,10 @@ function vsCodeGetConfigValue($value, $key, $configPaths) {
       }
     }
 
+    if (is_object($value)) {
+      $value = get_class($value);
+    }
+
     return [
       "name" => $key,
       "value" => $value,


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/48

If someone has an enum (or a classic object) in a config file, then the extension throws the error:

```bash
2025-02-09 14:26:34.706 [error] Configs

Error: __VSCODE_LARAVEL_START_OUTPUT____VSCODE_LARAVEL_END_OUTPUT__
```

This PR adds an additional check to see if the value is an object, if so, it just takes the classname:

![enum1](https://github.com/user-attachments/assets/bc965a81-7f18-4e30-9930-0ced7f1b7c80)

![enum2](https://github.com/user-attachments/assets/68f0e312-85de-406b-b6aa-ea58068b1e0a)
