### PR TITLE
Fix SyntaxError: Unexpected end of JSON input

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -147,7 +147,7 @@ export const detect = async (
 
     const promise = runCommand(`detect "${cleanArg(code)}"`)
         .then((result: string) => {
-            return JSON.parse(result);
+            return result.length > 0 ? JSON.parse(result) : result;
         })
         .catch((err) => {
             showErrorPopup(err);


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/309

The result in this line > https://github.com/laravel/vs-code-extension/blob/main/src/support/parser.ts#L150 can be an empty string (we don't know why, maybe performance issues?), then `JSON.parse` throws the error:

```bash
2025-05-21 21:44:29.841 [error] SyntaxError: Unexpected end of JSON input at JSON.parse (<anonymous>) at /home/.../.vscode-server/extensions/laravel.vscode-laravel-1.0.8/dist/extension.js:1573:1627
```

This PR adds an additional check if the result is empty, if so - JSON.parse is skipped.