### PR TITLE
Fix Translation detection breaks when there are blank lines in a JSON file

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -133,7 +133,7 @@ $translator = new class
             array_keys($json),
         );
         $result = [];
-        $searchRange = 2;
+        $searchRange = 3;
 
         foreach ($encoded as $index => $keys) {
             // Pretty likely to be on the line that is the index, go happy path first

--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -133,7 +133,7 @@ $translator = new class
             array_keys($json),
         );
         $result = [];
-        $searchRange = 3;
+        $searchRange = 5;
 
         foreach ($encoded as $index => $keys) {
             // Pretty likely to be on the line that is the index, go happy path first
@@ -142,7 +142,7 @@ $translator = new class
                 continue;
             }
 
-            // Search around the index, like to be within 2 lines
+            // Search around the index, likely to be within $searchRange lines
             $start = max(0, $index - $searchRange);
             $end = min($index + $searchRange, count($lines) - 1);
             $current = $start;

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -133,7 +133,7 @@ $translator = new class
             array_keys($json),
         );
         $result = [];
-        $searchRange = 2;
+        $searchRange = 3;
 
         foreach ($encoded as $index => $keys) {
             // Pretty likely to be on the line that is the index, go happy path first

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -133,7 +133,7 @@ $translator = new class
             array_keys($json),
         );
         $result = [];
-        $searchRange = 3;
+        $searchRange = 5;
 
         foreach ($encoded as $index => $keys) {
             // Pretty likely to be on the line that is the index, go happy path first
@@ -142,7 +142,7 @@ $translator = new class
                 continue;
             }
 
-            // Search around the index, like to be within 2 lines
+            // Search around the index, likely to be within $searchRange lines
             $start = max(0, $index - $searchRange);
             $end = min($index + $searchRange, count($lines) - 1);
             $current = $start;


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/396

This PR increases `$searchRange` in translation files to 3 to allow users using empty lines to separate some groups of strings and improve readability.