### PR TITLE
Fix Translation not found when contains non-standard character

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -129,7 +129,7 @@ $translator = new class
 
         $lines = explode(PHP_EOL, $contents);
         $encoded = array_map(
-            fn($k) => [json_encode($k), $k],
+            fn($k) => [json_encode($k, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), $k],
             array_keys($json),
         );
         $result = [];
@@ -364,4 +364,4 @@ echo json_encode([
     'values' => array_keys($translator->values),
     'params' => array_map(fn($p) => json_decode($p, true), array_keys($translator->paramResults)),
     'to_watch' => $translator->directoriesToWatch,
-]);
+], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -129,7 +129,7 @@ $translator = new class
 
         $lines = explode(PHP_EOL, $contents);
         $encoded = array_map(
-            fn($k) => [json_encode($k), $k],
+            fn($k) => [json_encode($k, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), $k],
             array_keys($json),
         );
         $result = [];
@@ -364,5 +364,5 @@ echo json_encode([
     'values' => array_keys($translator->values),
     'params' => array_map(fn($p) => json_decode($p, true), array_keys($translator->paramResults)),
     'to_watch' => $translator->directoriesToWatch,
-]);
+], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 `;


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/400

This PR depends on https://github.com/laravel/vs-code-php-parser-cli/pull/21

Currently, the `translations.php` template uses `json_encode` without any flags. As a result, during serialization to JSON, all symbols and slashes are escaped. For example:

`Products → Settings` => `Products \u2192 Settings`

`API / ERP` => `API \/ ERP`

then linkProvider cannot find such elements in the translation repository, because VsCode returns raw, unescaped keys.

This PR adds 2 additional flags to json_encode: JSON_UNESCAPED_UNICODE and JSON_UNESCAPED_SLASHES. As far as I know, both javascript object and php array can use symbols and slashes in the property/key names, so there should be no conflict.