### PR TITLE
Memory improvements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,11 @@ import {
 } from "./support/fileWatcher";
 import { info } from "./support/logger";
 import { clearParserCaches, setParserBinaryPath } from "./support/parser";
-import { clearDefaultPhpCommand, initVendorWatchers } from "./support/php";
+import {
+    clearDefaultPhpCommand,
+    clearPhpFileCache,
+    initVendorWatchers,
+} from "./support/php";
 import { hasWorkspace, projectPathExists } from "./support/project";
 import { cleanUpTemp } from "./support/util";
 
@@ -186,6 +190,7 @@ export function deactivate() {
 
     disposeWatchers();
     clearParserCaches();
+    clearPhpFileCache();
 
     if (client) {
         client.stop();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import {
     watchForComposerChanges,
 } from "./support/fileWatcher";
 import { info } from "./support/logger";
-import { setParserBinaryPath } from "./support/parser";
+import { clearParserCaches, setParserBinaryPath } from "./support/parser";
 import { clearDefaultPhpCommand, initVendorWatchers } from "./support/php";
 import { hasWorkspace, projectPathExists } from "./support/project";
 import { cleanUpTemp } from "./support/util";
@@ -185,6 +185,7 @@ export function deactivate() {
     }
 
     disposeWatchers();
+    clearParserCaches();
 
     if (client) {
         client.stop();

--- a/src/support/cache.ts
+++ b/src/support/cache.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+
 export class Cache<K, V> {
     private maxSize: number;
     private cache: Map<K, V>;
@@ -42,5 +44,80 @@ export class Cache<K, V> {
 
     size(): number {
         return this.cache.size;
+    }
+}
+
+export class BoundedFileCache {
+    private cache = new Map<string, string>();
+    private maxSize: number;
+
+    constructor(maxSize: number) {
+        this.maxSize = maxSize;
+    }
+
+    get(key: string): string | undefined {
+        return this.cache.get(key);
+    }
+
+    set(key: string, filePath: string): void {
+        if (this.cache.has(key)) {
+            return;
+        }
+
+        if (this.cache.size >= this.maxSize) {
+            const oldestKey = this.cache.keys().next().value;
+            if (oldestKey !== undefined) {
+                const oldFilePath = this.cache.get(oldestKey);
+                if (oldFilePath && fs.existsSync(oldFilePath)) {
+                    try {
+                        fs.unlinkSync(oldFilePath);
+                    } catch (e) {
+                        // File might already be deleted, ignore
+                    }
+                }
+                this.cache.delete(oldestKey);
+            }
+        }
+
+        this.cache.set(key, filePath);
+    }
+
+    has(key: string): boolean {
+        return this.cache.has(key);
+    }
+
+    delete(key: string): void {
+        const filePath = this.cache.get(key);
+
+        if (filePath && fs.existsSync(filePath)) {
+            try {
+                fs.unlinkSync(filePath);
+            } catch (e) {
+                // File might already be deleted, ignore
+            }
+        }
+
+        this.cache.delete(key);
+    }
+
+    clear(): void {
+        for (const [key] of this.cache.entries()) {
+            this.delete(key);
+        }
+
+        this.cache.clear();
+    }
+
+    size(): number {
+        return this.cache.size;
+    }
+
+    deleteByFilePath(filePath: string): void {
+        for (const [key, value] of this.cache.entries()) {
+            if (value === filePath) {
+                this.cache.delete(key);
+                break;
+            }
+        }
     }
 }

--- a/src/support/cache.ts
+++ b/src/support/cache.ts
@@ -1,0 +1,46 @@
+export class Cache<K, V> {
+    private maxSize: number;
+    private cache: Map<K, V>;
+
+    constructor(maxSize: number) {
+        this.maxSize = maxSize;
+        this.cache = new Map();
+    }
+
+    get(key: K): V | undefined {
+        const value = this.cache.get(key);
+
+        if (value !== undefined) {
+            this.cache.delete(key);
+            this.cache.set(key, value);
+        }
+
+        return value;
+    }
+
+    set(key: K, value: V): void {
+        if (this.cache.has(key)) {
+            this.cache.delete(key);
+        } else if (this.cache.size >= this.maxSize) {
+            const firstKey = this.cache.keys().next().value;
+
+            if (firstKey !== undefined) {
+                this.cache.delete(firstKey);
+            }
+        }
+
+        this.cache.set(key, value);
+    }
+
+    has(key: K): boolean {
+        return this.cache.has(key);
+    }
+
+    clear(): void {
+        this.cache.clear();
+    }
+
+    size(): number {
+        return this.cache.size;
+    }
+}

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -175,4 +175,8 @@ export const registerWatcher = (watcher: vscode.FileSystemWatcher) => {
 export const disposeWatchers = () => {
     watchers.forEach((watcher) => watcher.dispose());
     watchers = [];
+
+    for (const pattern in patternWatchers) {
+        delete patternWatchers[pattern];
+    }
 };

--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -9,14 +9,20 @@ import * as fs from "fs";
 import * as os from "os";
 import * as vscode from "vscode";
 import { FeatureTag, ValidDetectParamTypes } from "..";
+import { Cache } from "./cache";
 import { showErrorPopup } from "./popup";
 import { md5, tempPath, toArray } from "./util";
 
-const currentlyParsing = new Map<string, Promise<AutocompleteResult>>();
-const detected = new Map<
+const currentlyParsing = new Cache<string, Promise<AutocompleteResult>>(100);
+const detected = new Cache<
     string,
     Promise<AutocompleteParsingResult.ContextValue[]>
->();
+>(50);
+
+export const clearParserCaches = (): void => {
+    currentlyParsing.clear();
+    detected.clear();
+};
 
 type TokenFormatted = [string, string, number];
 type Token = string | TokenFormatted;

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -2,6 +2,7 @@ import { getTemplate, TemplateName } from "@src/templates";
 import * as cp from "child_process";
 import * as fs from "fs";
 import * as vscode from "vscode";
+import { BoundedFileCache } from "./cache";
 import { config, PhpEnvironment } from "./config";
 import { registerWatcher } from "./fileWatcher";
 import { error, info } from "./logger";
@@ -24,7 +25,7 @@ const toTemplateVar = (str: string) => {
 
 let defaultPhpCommand: string | null = null;
 
-const discoverFiles = new Map<string, string>();
+const discoverFiles = new BoundedFileCache(50);
 
 let hasVendor = projectPathExists("vendor/autoload.php");
 const hasBootstrap = projectPathExists("bootstrap/app.php");
@@ -46,12 +47,7 @@ export const initVendorWatchers = () => {
     );
 
     watcher.onDidDelete((file) => {
-        for (const [key, value] of discoverFiles) {
-            if (value === file.fsPath) {
-                discoverFiles.delete(key);
-                break;
-            }
-        }
+        discoverFiles.deleteByFilePath(file.fsPath);
     });
 
     [internalVendorPath(), projectPath("vendor")].forEach((path) => {
@@ -171,6 +167,10 @@ const getPhpCommand = (): string => {
 
 export const clearDefaultPhpCommand = () => {
     defaultPhpCommand = null;
+};
+
+export const clearPhpFileCache = () => {
+    discoverFiles.clear();
 };
 
 const getDefaultPhpCommand = (): string => {


### PR DESCRIPTION
Wherever we were caching in a `Map` it was unbounded, there was no limit to the number of items that could be stored in them. This PR implements a sensible upper bound for each cache so that evicts entries once the bound is reached.

It also does a bit of extra cleanup in some areas where we weren't deleting files or maps once the extension shut down.