### PR TITLE
Fix for translations with numeric keys

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -169,10 +169,11 @@ $translator = new class
         $arrayDepth = -1;
         $depthKeys = [];
 
-        foreach ($tokens as $token) {
+        foreach ($tokens as $index => $token) {
             if (!is_array($token)) {
                 if ($token === '[') {
                     $inArrayKey = true;
+                    $currentIndex = 0;
                     $arrayDepth++;
                 }
 
@@ -190,6 +191,15 @@ $translator = new class
             }
 
             if ($inArrayKey && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
+                $nextToken = isset($tokens[$index + 1]) ? $tokens[$index + 1] : null;
+                $nextValue = isset($nextToken[1]) ? $nextToken[1] : $nextToken;
+
+                if ($nextValue === ',' || str_contains($nextValue, "\n")) {
+                    $token[1] = $currentIndex;
+
+                    $currentIndex++;
+                }
+
                 $depthKeys[$arrayDepth] = trim($token[1], '"\'');
 
                 \Illuminate\Support\Arr::set($found, implode('.', $depthKeys), $token[2]);

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -169,10 +169,11 @@ $translator = new class
         $arrayDepth = -1;
         $depthKeys = [];
 
-        foreach ($tokens as $token) {
+        foreach ($tokens as $index => $token) {
             if (!is_array($token)) {
                 if ($token === '[') {
                     $inArrayKey = true;
+                    $currentIndex = 0;
                     $arrayDepth++;
                 }
 
@@ -190,6 +191,15 @@ $translator = new class
             }
 
             if ($inArrayKey && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
+                $nextToken = isset($tokens[$index + 1]) ? $tokens[$index + 1] : null;
+                $nextValue = isset($nextToken[1]) ? $nextToken[1] : $nextToken;
+
+                if ($nextValue === ',' || str_contains($nextValue, "\\n")) {
+                    $token[1] = $currentIndex;
+
+                    $currentIndex++;
+                }
+
                 $depthKeys[$arrayDepth] = trim($token[1], '"\\'');
 
                 \\Illuminate\\Support\\Arr::set($found, implode('.', $depthKeys), $token[2]);


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/406

![obraz](https://github.com/user-attachments/assets/aa293493-c7b2-4293-a6e7-0ebad346f21d)

Before:

![obraz](https://github.com/user-attachments/assets/2acaf7b1-1203-4bed-a9c2-3a30de42e2d8)

After:

![obraz](https://github.com/user-attachments/assets/44154092-862e-45d8-a67b-4461b97cd957)
