### PR TITLE
Fix - resolve route controller paths

### DIFF
--- a/php-templates/routes.php
+++ b/php-templates/routes.php
@@ -8,6 +8,15 @@ $routes = new class {
             ->merge($this->getFolioRoutes());
     }
 
+    protected function getRelativePath($path)
+    {
+        $basePath = base_path() . DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $basePath)) {
+            return substr($path, strlen($basePath));
+        }
+        return $path;
+    }
+
     protected function getFolioRoutes()
     {
         try {
@@ -43,7 +52,7 @@ $routes = new class {
             'name' => $route['name'],
             'action' => null,
             'parameters' => [],
-            'filename' => $path,
+            'filename' => $this->getRelativePath($path),
             'line' => 0,
         ];
     }
@@ -64,7 +73,7 @@ $routes = new class {
             'name' => $route->getName(),
             'action' => $route->getActionName(),
             'parameters' => $route->parameterNames(),
-            'filename' => $reflection ? $reflection->getFileName() : null,
+            'filename' => $reflection ? $this->getRelativePath($reflection->getFileName()) : null,
             'line' => $reflection ? $reflection->getStartLine() : null,
         ];
     }

--- a/src/features/route.ts
+++ b/src/features/route.ts
@@ -88,7 +88,7 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
 
             return new vscode.DocumentLink(
                 detectedRange(param),
-                vscode.Uri.file(route.filename).with({
+                vscode.Uri.file(projectPath(route.filename)).with({
                     fragment: `L${route.line ?? 0}`,
                 }),
             );

--- a/src/templates/routes.ts
+++ b/src/templates/routes.ts
@@ -8,6 +8,15 @@ $routes = new class {
             ->merge($this->getFolioRoutes());
     }
 
+    protected function getRelativePath($path)
+    {
+        $basePath = base_path() . DIRECTORY_SEPARATOR;
+        if (str_starts_with($path, $basePath)) {
+            return substr($path, strlen($basePath));
+        }
+        return $path;
+    }
+
     protected function getFolioRoutes()
     {
         try {
@@ -43,7 +52,7 @@ $routes = new class {
             'name' => $route['name'],
             'action' => null,
             'parameters' => [],
-            'filename' => $path,
+            'filename' => $this->getRelativePath($path),
             'line' => 0,
         ];
     }
@@ -64,7 +73,7 @@ $routes = new class {
             'name' => $route->getName(),
             'action' => $route->getActionName(),
             'parameters' => $route->parameterNames(),
-            'filename' => $reflection ? $reflection->getFileName() : null,
+            'filename' => $reflection ? $this->getRelativePath($reflection->getFileName()) : null,
             'line' => $reflection ? $reflection->getStartLine() : null,
         ];
     }


### PR DESCRIPTION
**Before:**
<img width="476" alt="image" src="https://github.com/user-attachments/assets/f8dfd31b-012f-497c-8d71-5495759adbd7" />

`Ctrl / CMD` + Click does not resolve controller path:
![image](https://github.com/user-attachments/assets/9bab24d1-4954-4273-abc9-c70b92e818c2)


**After:**
<img width="459" alt="image" src="https://github.com/user-attachments/assets/25613984-66d6-4aab-a3fd-fca28c265f2a" />

`Ctrl / CMD` + Click resolved controller path and method:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/07c678f2-a7c6-4ee8-9861-5c7a0638088a" />
