### PR TITLE
Fix bug with unnecessary autocompletion blade components when name doesn't match

### DIFF
--- a/src/features/bladeComponent.ts
+++ b/src/features/bladeComponent.ts
@@ -73,7 +73,7 @@ export const completionProvider: vscode.CompletionItemProvider = {
                 pos.character,
             );
 
-            return linePrefix !== prefix;
+            return linePrefix === prefix;
         });
 
         if (!match) {


### PR DESCRIPTION
I think there is a bug in this line > https://github.com/laravel/vs-code-extension/blob/main/src/features/bladeComponent.ts#L76

Currently, autocompletion blade components apears every time, even if a user uses emmet, for example:

![obraz](https://github.com/user-attachments/assets/212a190e-8de9-4bb2-bad2-d48b619865c9)

This was reported in this issue https://github.com/laravel/vs-code-extension/issues/392