### PR TITLE
Fix for Blade::anonymousComponentPath with double colon

### DIFF
--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -180,10 +180,19 @@ $components = new class {
                 ...$this->findFiles(
                     $item['path'],
                     'blade.php',
-                    fn($key) => $key
-                        ->kebab()
-                        ->prepend(($item['prefix'] ?? ':') . ':')
-                        ->ltrim(':'),
+                    function (\Illuminate\Support\Stringable $key) use ($item) {
+                        $prefix = $item['prefix'] ? $item['prefix'] . '::' : '';
+                        $key = $key->kebab();
+                        $keys = [];
+
+                        $keys[] = $key->prepend($prefix);
+
+                        if ($item['prefix'] === 'flux') {
+                            $keys[] = $key->prepend('flux:');
+                        }
+
+                        return $keys;
+                    },
                 )
             );
 

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -180,10 +180,19 @@ $components = new class {
                 ...$this->findFiles(
                     $item['path'],
                     'blade.php',
-                    fn($key) => $key
-                        ->kebab()
-                        ->prepend(($item['prefix'] ?? ':') . ':')
-                        ->ltrim(':'),
+                    function (\\Illuminate\\Support\\Stringable $key) use ($item) {
+                        $prefix = $item['prefix'] ? $item['prefix'] . '::' : '';
+                        $key = $key->kebab();
+                        $keys = [];
+
+                        $keys[] = $key->prepend($prefix);
+
+                        if ($item['prefix'] === 'flux') {
+                            $keys[] = $key->prepend('flux:');
+                        }
+
+                        return $keys;
+                    },
                 )
             );
 


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/418

There is a bug with registering anonymous component paths in this line > https://github.com/laravel/vs-code-extension/blob/main/php-templates/blade-components.php#L185

If a prefix is present, then the extension uses single colon, but according to the [Laravel documentation](https://laravel.com/docs/12.x/blade#anonymous-component-paths), anonymous components with a prefix use double colon, for example:

```php
<x-dashboard::panel />
```

Caleb's [Flux](https://github.com/livewire/flux) is a specific case, because he uses his own [Compiler](https://github.com/livewire/flux/blob/main/src/FluxTagCompiler.php) to compile something like this:

```php
<flux:button />
```

This PR replaces a single colon to a double colon:

![obraz](https://github.com/user-attachments/assets/38a8cce0-a69b-4b86-8ae3-570c284465bf)

and adds support for Flux with an additonal key, so the extension recognizes its components in both forms:

![obraz](https://github.com/user-attachments/assets/f7a41082-4e9b-48c1-a610-5904ab400d1e)

![obraz](https://github.com/user-attachments/assets/ce100d26-c089-419c-af57-96ca939c619f)
