### PR TITLE
Add support for root-level Inertia configs

### DIFF
--- a/php-templates/inertia.php
+++ b/php-templates/inertia.php
@@ -1,8 +1,8 @@
 <?php
 
 echo json_encode([
-    ...config('inertia.testing', []),
-    'page_paths' => collect(config('inertia.testing.page_paths', []))->flatMap(function($path) {
+    'page_extensions' => config('inertia.page_extensions', config('inertia.testing.page_extensions', [])),
+    'page_paths' => collect(config('inertia.page_paths', config('inertia.testing.page_paths', [])))->flatMap(function($path) {
         $relativePath = LaravelVsCode::relativePath($path);
 
         return [$relativePath, mb_strtolower($relativePath)];

--- a/src/templates/inertia.ts
+++ b/src/templates/inertia.ts
@@ -1,8 +1,8 @@
 // This file was generated from php-templates/inertia.php, do not edit directly
 export default `
 echo json_encode([
-    ...config('inertia.testing', []),
-    'page_paths' => collect(config('inertia.testing.page_paths', []))->flatMap(function($path) {
+    'page_extensions' => config('inertia.page_extensions', config('inertia.testing.page_extensions', [])),
+    'page_paths' => collect(config('inertia.page_paths', config('inertia.testing.page_paths', [])))->flatMap(function($path) {
         $relativePath = LaravelVsCode::relativePath($path);
 
         return [$relativePath, mb_strtolower($relativePath)];


### PR DESCRIPTION
`Testing` Inertia configs are deprecated and will be removed > https://github.com/inertiajs/inertia-laravel/blob/2.x/config/inertia.php#L77-L79

This PR adds support for root-level configs, but old `testing` are still recognized if newer ones don't exist.