### PR TITLE
Add support for custom View extensions

### DIFF
--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -86,9 +86,12 @@ $blade = new class {
             return $paths;
         }
 
+        $finder = app("view")->getFinder();
+        $extensions = array_map(fn($extension) => ".{$extension}", $finder->getExtensions());
+
         $files = \Symfony\Component\Finder\Finder::create()
             ->files()
-            ->name("*.blade.php")
+            ->name(array_map(fn ($ext) => "*{$ext}", $extensions))
             ->in($path);
 
         foreach ($files as $file) {
@@ -97,7 +100,7 @@ $blade = new class {
                 "isVendor" => str_contains($file->getRealPath(), base_path("vendor")),
                 "key" => str($file->getRealPath())
                     ->replace(realpath($path), "")
-                    ->replace(".blade.php", "")
+                    ->replace($extensions, "")
                     ->ltrim(DIRECTORY_SEPARATOR)
                     ->replace(DIRECTORY_SEPARATOR, ".")
             ];

--- a/src/templates/views.ts
+++ b/src/templates/views.ts
@@ -86,9 +86,12 @@ $blade = new class {
             return $paths;
         }
 
+        $finder = app("view")->getFinder();
+        $extensions = array_map(fn($extension) => ".{$extension}", $finder->getExtensions());
+
         $files = \\Symfony\\Component\\Finder\\Finder::create()
             ->files()
-            ->name("*.blade.php")
+            ->name(array_map(fn ($ext) => "*{$ext}", $extensions))
             ->in($path);
 
         foreach ($files as $file) {
@@ -97,7 +100,7 @@ $blade = new class {
                 "isVendor" => str_contains($file->getRealPath(), base_path("vendor")),
                 "key" => str($file->getRealPath())
                     ->replace(realpath($path), "")
-                    ->replace(".blade.php", "")
+                    ->replace($extensions, "")
                     ->ltrim(DIRECTORY_SEPARATOR)
                     ->replace(DIRECTORY_SEPARATOR, ".")
             ];


### PR DESCRIPTION
This pull request adds support for custom View extensions during autocomplete.

The extension doesn't currently support this, which is painful internally since we use `.blade.sh` for script files powered by Blade and don't get any suggestions when calling `view()` for those files.