### PR TITLE
Add a command that wraps selected text with a helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
         "submenus": [
             {
                 "id": "laravel.wrapHelpers.submenu",
-                "label": "Laravel: Wrap selection with helpers",
-                "icon": "$(symbol-keyword)"
+                "label": "Laravel: Wrap selection with helpers"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,105 @@
         }
     ],
     "contributes": {
+        "commands": [
+            {
+                "command": "laravel.wrapHelpers",
+                "title": "Laravel: Wrap selection with helpers"
+            },
+            {
+                "command": "laravel.wrapHelpers.unwrap",
+                "title": "Laravel: Unwrap selection"
+            },
+            {
+                "command": "laravel.wrapHelpers.dd",
+                "title": "with dd(...)"
+            },
+            {
+                "command": "laravel.wrapHelpers.dump",
+                "title": "with dump(...)"
+            },
+            {
+                "command": "laravel.wrapHelpers.collect",
+                "title": "with collect(...)"
+            },
+            {
+                "command": "laravel.wrapHelpers.str",
+                "title": "with str(...)"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "laravel.wrapHelpers.dd",
+                "key": "shift+alt+d",
+                "when": "editorTextFocus && editorHasSelection"
+            },
+            {
+                "command": "laravel.wrapHelpers.unwrap",
+                "key": "shift+alt+u",
+                "when": "editorTextFocus && editorHasSelection"
+            }
+        ],
+        "submenus": [
+            {
+                "id": "laravel.wrapHelpers.submenu",
+                "label": "Laravel: Wrap selection with helpers",
+                "icon": "$(symbol-keyword)"
+            }
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "laravel.wrapHelpers",
+                    "when": "editorHasSelection"
+                },
+                {
+                    "command": "laravel.wrapHelpers.unwrap",
+                    "when": "editorHasSelection"
+                },
+                {
+                    "command": "laravel.wrapHelpers.dd",
+                    "when": "false"
+                },
+                {
+                    "command": "laravel.wrapHelpers.dump",
+                    "when": "false"
+                },
+                {
+                    "command": "laravel.wrapHelpers.collect",
+                    "when": "false"
+                },
+                {
+                    "command": "laravel.wrapHelpers.str",
+                    "when": "false"
+                }
+            ], 
+            "editor/context": [
+                {
+                    "submenu": "laravel.wrapHelpers.submenu",
+                    "when": "editorHasSelection",
+                    "group": "laravel"
+                },
+                {
+                    "command": "laravel.wrapHelpers.unwrap",
+                    "when": "editorHasSelection",
+                    "group": "laravel"
+                }
+            ],
+            "laravel.wrapHelpers.submenu": [
+                {
+                    "command": "laravel.wrapHelpers.dd"
+                },
+                {
+                    "command": "laravel.wrapHelpers.dump"
+                },
+                {
+                    "command": "laravel.wrapHelpers.collect"
+                },
+                {
+                    "command": "laravel.wrapHelpers.str"
+                }
+            ]            
+        }, 
         "languages": [
             {
                 "id": "blade",

--- a/src/commands/wrapHelpers.ts
+++ b/src/commands/wrapHelpers.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+
+export const helpers = ['dd', 'dump', 'collect', 'str'];
+
+export const openSubmenu = async () => {
+    const choice = await vscode.window.showQuickPick(
+        helpers.map((helper: string) => {
+            return {
+                label: `with ${helper}(...)`,
+                command: `laravel.wrapHelpers.${helper}`
+            };
+        }),
+        {
+            placeHolder: 'Choose a wrap'
+        }
+    );
+
+    if (choice) {
+        vscode.commands.executeCommand(choice.command);
+    }
+};
+
+export const wrapSelection = (wrapper: string) => {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+        return;
+    }
+
+    const selection = editor.selection;
+    let selectedText = editor.document.getText(selection);
+    const hasSemicolon = selectedText.at(-1) === ';';
+
+    if (hasSemicolon) {
+        selectedText = selectedText.slice(0, -1);
+    }
+
+    let transformed = `${wrapper}(${selectedText})`;
+
+    if (hasSemicolon) {
+        transformed += ';';
+    }
+
+    editor.edit(editBuilder => {
+        editBuilder.replace(selection, transformed);
+    });
+};
+
+export const unwrapSelection = () => {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+        return;
+    }
+
+    const selection = editor.selection;
+    const selectedText = editor.document.getText(selection);
+
+    const transformed = selectedText.replace(/[a-zA-Z0-9_]+\(([\s\S]+)\)(?!\))/, '$1');
+
+    editor.edit(editBuilder => {
+        editBuilder.replace(selection, transformed);
+    });
+};

--- a/src/commands/wrapHelpers.ts
+++ b/src/commands/wrapHelpers.ts
@@ -56,6 +56,12 @@ export const unwrapSelection = () => {
     const selection = editor.selection;
     const selectedText = editor.document.getText(selection);
 
+    const match = selectedText.match(/^([a-zA-Z0-9_]+)\(/);
+
+    if (match !== null && match[1] !== undefined && !helpers.includes(match[1])) {
+        return;
+    }
+
     const transformed = selectedText.replace(/[a-zA-Z0-9_]+\(([\s\S]+)\)(?!\))/, '$1');
 
     editor.edit(editBuilder => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { bladeSpacer } from "./blade/bladeSpacer";
 import { initClient } from "./blade/client";
 import { openFileCommand } from "./commands";
+import { helpers, openSubmenu, unwrapSelection, wrapSelection } from "./commands/wrapHelpers";
 import { configAffected } from "./support/config";
 import { collectDebugInfo } from "./support/debug";
 import {
@@ -188,6 +189,11 @@ export async function activate(context: vscode.ExtensionContext) {
             },
         ),
         vscode.commands.registerCommand("laravel.open", openFileCommand),
+        vscode.commands.registerCommand("laravel.wrapHelpers", openSubmenu),
+        vscode.commands.registerCommand("laravel.wrapHelpers.unwrap", unwrapSelection),
+        ...helpers.map((helper: string) => {
+            return vscode.commands.registerCommand(`laravel.wrapHelpers.${helper}`, () => wrapSelection(helper));
+        })
     );
 
     collectDebugInfo();


### PR DESCRIPTION
This PR adds a command that wraps selected text with a helper. This command is especially useful with the `dd()` helper.

The command is available by default through keyboard shortcuts: SHIFT+ALT+D (wrap) and SHIFT+ALT+U (unwrap)

![wrap-helpers](https://github.com/user-attachments/assets/4a0c292c-0732-4d5a-b686-bfd586b31c4a)

from the context menu:

<img width="730" height="142" alt="obraz" src="https://github.com/user-attachments/assets/977cf99b-82ec-4dfd-a358-bbb732af447e" />

and from the command palette:

<img width="728" height="86" alt="obraz" src="https://github.com/user-attachments/assets/04abb665-afe8-4d83-a398-29ed5deedfb4" />

I was inspired by a feature from Laravel Idea plugin for PHPStorm.