### PR TITLE
Add commands that refactor class attributes in blade files

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,17 @@
     "contributes": {
         "commands": [
             {
-                "command": "laravel.refactorClass",
-                "title": "Laravel: Refactor class attribute"
+                "command": "laravel.refactorSelectedClass",
+                "title": "Laravel: Refactor selected class attribute"
+            },
+            {
+                "command": "laravel.refactorAllClasses",
+                "title": "Laravel: Refactor all class attributes"
             }
         ],
         "keybindings": [
             {
-                "command": "laravel.refactorClass",
+                "command": "laravel.refactorSelectedClass",
                 "key": "shift+alt+c",
                 "when": "editorHasSelection && resourceLangId == blade"
             }
@@ -58,17 +62,27 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "laravel.refactorClass",
+                    "command": "laravel.refactorSelectedClass",
                     "when": "editorHasSelection && resourceLangId == blade",
+                    "group": "laravel"
+                },
+                {
+                    "command": "laravel.refactorAllClasses",
+                    "when": "resourceLangId == blade",
                     "group": "laravel"
                 }
             ],
             "editor/context": [
                 {
-                    "command": "laravel.refactorClass",
+                    "command": "laravel.refactorSelectedClass",
                     "when": "editorHasSelection && resourceLangId == blade",
                     "group": "laravel"
-                }                
+                },
+                {
+                    "command": "laravel.refactorAllClasses",
+                    "when": "resourceLangId == blade",
+                    "group": "laravel"
+                }
             ]            
         },
         "languages": [

--- a/package.json
+++ b/package.json
@@ -42,6 +42,35 @@
         }
     ],
     "contributes": {
+        "commands": [
+            {
+                "command": "laravel.refactorClass",
+                "title": "Laravel: Refactor class attribute"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "laravel.refactorClass",
+                "key": "shift+alt+c",
+                "when": "editorHasSelection && resourceLangId == blade"
+            }
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "laravel.refactorClass",
+                    "when": "editorHasSelection && resourceLangId == blade",
+                    "group": "laravel"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "laravel.refactorClass",
+                    "when": "editorHasSelection && resourceLangId == blade",
+                    "group": "laravel"
+                }                
+            ]            
+        },
         "languages": [
             {
                 "id": "blade",

--- a/src/commands/refactorClass.ts
+++ b/src/commands/refactorClass.ts
@@ -20,7 +20,7 @@ export const refactorAllClassesCommand = () => {
     const document = editor.document;
     const fullText = document.getText();
 
-    const transformed = fullText.replace(/(?<!:)class="([^"]+)"/g, (_, classList) => {
+    const transformed = fullText.replace(/(?<!:)class="(.+?)"/g, (_, classList) => {
         return transformClass(classList);
     });
 
@@ -44,13 +44,13 @@ export const refactorSelectedClassCommand = () => {
     const selection = editor.selection;
     const selectedText = editor.document.getText(selection);
 
-    const match = selectedText.match(/(?<!:)class="([\s\S]+)"/);
+    const match = selectedText.match(/(?<!:)class="(.+?)"/);
 
     if (!match) {
         return;
     }
 
-    const transformed = selectedText.replace(/(?<!:)class="([\s\S]+)"/, transformClass(match[1]));
+    const transformed = selectedText.replace(/(?<!:)class="(.+?)"/, transformClass(match[1]));
 
     editor.edit(editBuilder => {
         editBuilder.replace(selection, transformed);

--- a/src/commands/refactorClass.ts
+++ b/src/commands/refactorClass.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode";
+
+export const refactorClassCommand = () => {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+        return;
+    }
+
+    const selection = editor.selection;
+    const selectedText = editor.document.getText(selection);
+
+    const match = selectedText.match(/class="([\s\S]+)"/);
+
+    if (!match) {
+        return;
+    }
+
+    const classes = match[1]
+        .trim()
+        .split(/\s+/)
+        .map(cls => `'${cls}'`)
+        .join(', ');
+
+    const transformed = `@class([${classes}])`;
+
+    editor.edit(editBuilder => {
+        editBuilder.replace(selection, transformed);
+    });
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { bladeSpacer } from "./blade/bladeSpacer";
 import { initClient } from "./blade/client";
 import { openFileCommand } from "./commands";
+import { refactorClassCommand } from "./commands/refactorClass";
 import { configAffected } from "./support/config";
 import { collectDebugInfo } from "./support/debug";
 import {
@@ -188,6 +189,7 @@ export async function activate(context: vscode.ExtensionContext) {
             },
         ),
         vscode.commands.registerCommand("laravel.open", openFileCommand),
+        vscode.commands.registerCommand("laravel.refactorClass", refactorClassCommand),
     );
 
     collectDebugInfo();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { bladeSpacer } from "./blade/bladeSpacer";
 import { initClient } from "./blade/client";
 import { openFileCommand } from "./commands";
-import { refactorClassCommand } from "./commands/refactorClass";
+import { refactorAllClassesCommand, refactorSelectedClassCommand } from "./commands/refactorClass";
 import { configAffected } from "./support/config";
 import { collectDebugInfo } from "./support/debug";
 import {
@@ -189,7 +189,8 @@ export async function activate(context: vscode.ExtensionContext) {
             },
         ),
         vscode.commands.registerCommand("laravel.open", openFileCommand),
-        vscode.commands.registerCommand("laravel.refactorClass", refactorClassCommand),
+        vscode.commands.registerCommand("laravel.refactorSelectedClass", refactorSelectedClassCommand),
+        vscode.commands.registerCommand("laravel.refactorAllClasses", refactorAllClassesCommand),
     );
 
     collectDebugInfo();


### PR DESCRIPTION
This PR adds a command that refactor a selected or all class(es) attribute{s) to blade directive(s).

The "selected" command is available by default through keyboard shortcut: SHIFT+ALT+C

![ezgif-780dfa5e554837](https://github.com/user-attachments/assets/d206402e-076d-4290-ada5-487886a4915f)

Both commands are available from the context menu:

<img width="506" height="68" alt="obraz" src="https://github.com/user-attachments/assets/8496f44f-6d7f-462f-9a91-2c39bc127751" />

and from the command palette:

<img width="762" height="88" alt="obraz" src="https://github.com/user-attachments/assets/7c4a0393-0394-4938-815d-ec064c35d72e" />

I was inspired by a feature from Laravel Idea plugin for PHPStorm.