### PR TITLE
Fix for getTranslationPathByName with nested translations

### DIFF
--- a/src/repositories/translations.ts
+++ b/src/repositories/translations.ts
@@ -84,7 +84,7 @@ export const getTranslationPathByName = (
 ): string | undefined => {
     lang = lang ?? getTranslations().items.default;
 
-    const fileName = match.replace(/^.*::/, "").replace(/\.[^.]+$/, "");
+    const fileName = match.replace(/^.*::/, "").replace(/^([^.]+)\..*$/, "$1");
 
     return getTranslations().items.paths.find((path) => {
         return (


### PR DESCRIPTION
I made a mistake with my previous PR https://github.com/laravel/vs-code-extension/pull/415

Currently, the linked parameter works only for first-level translations:

<img width="883" height="101" alt="460779166-ed98230e-a3ca-43e9-b419-a19a513f1799" src="https://github.com/user-attachments/assets/c1ce0206-9415-408e-b30c-8102f494b162" />

but not for next-level translations:

<img width="992" height="124" alt="obraz" src="https://github.com/user-attachments/assets/24bf860c-ab4f-4c92-8063-a7c78b8e02d0" />

This PR fixes this issue:

<img width="1012" height="124" alt="obraz" src="https://github.com/user-attachments/assets/c02375a3-127f-4311-a2a7-6cb29b161d2b" />
