### PR TITLE
Add Pint formatter to the available list

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -136,3 +136,11 @@ export const runPintOnSave = (document: vscode.TextDocument) => {
 
     runPintOnFile(document.uri.fsPath, false);
 };
+
+export class PintEditProvider implements vscode.DocumentFormattingEditProvider {
+    provideDocumentFormattingEdits() {
+        runPintOnCurrentFile();
+
+        return [];
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { bladeSpacer } from "./blade/bladeSpacer";
 import { initClient } from "./blade/client";
 import {
     openFileCommand,
+    PintEditProvider,
     runPint,
     runPintOnCurrentFile,
     runPintOnDirtyFiles,
@@ -142,6 +143,10 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeTextDocument((event) => {
             bladeSpacer(event, vscode.window.activeTextEditor);
         }),
+        vscode.languages.registerDocumentFormattingEditProvider(
+            { language: "php" },
+            new PintEditProvider(),
+        ),
         // vscode.languages.registerDocumentHighlightProvider(
         //     documentSelector,
         //     new DocumentHighlight(),


### PR DESCRIPTION
Currently if a user wants to use the Pint formatter feature > https://github.com/laravel/vs-code-extension/pull/448 he needs to use the "Run Pint" command or enable the "Pint on save" option in the config.

If he tries to use a built-in VSCode command "Format Document":

<img width="728" height="108" alt="obraz" src="https://github.com/user-attachments/assets/9e916a0d-5a5d-4cc5-91e2-3011ea0475bf" />

he gets:

<img width="372" height="136" alt="obraz" src="https://github.com/user-attachments/assets/c7113db6-8846-431e-a7de-955332eca893" />

This PR registers the Pint formatter to the available list:

<img width="722" height="84" alt="obraz" src="https://github.com/user-attachments/assets/51c96c62-b507-407c-898f-10c83dbc3092" />

<img width="928" height="124" alt="obraz" src="https://github.com/user-attachments/assets/c70f27aa-5812-4fba-a669-64aef92d264f" />
