### PR TITLE
Fix - move refactor class commands from laravel.wrapWithHelper.submenu to editor/context

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,16 @@
                     "command": "laravel.wrapWithHelper.unwrap",
                     "when": "editorHasSelection",
                     "group": "laravel"
+                },
+                {
+                    "command": "laravel.refactorSelectedHtmlClassToBladeDirective",
+                    "when": "editorHasSelection && resourceLangId == blade",
+                    "group": "laravel"
+                },
+                {
+                    "command": "laravel.refactorAllHtmlClassesToBladeDirectives",
+                    "when": "resourceLangId == blade",
+                    "group": "laravel"
                 }
             ],
             "laravel.wrapWithHelper.submenu": [
@@ -115,16 +125,6 @@
                 },
                 {
                     "command": "laravel.wrapWithHelper.str"
-                },
-                {
-                    "command": "laravel.refactorSelectedHtmlClassToBladeDirective",
-                    "when": "editorHasSelection && resourceLangId == blade",
-                    "group": "laravel"
-                },
-                {
-                    "command": "laravel.refactorAllHtmlClassesToBladeDirectives",
-                    "when": "resourceLangId == blade",
-                    "group": "laravel"
                 }
             ]
         },


### PR DESCRIPTION
These commands are in the wrong place:

<img width="988" height="266" alt="obraz" src="https://github.com/user-attachments/assets/c7c2d55f-eb76-4806-b6b4-6ca20b86c1e3" />

Should be:

<img width="928" height="256" alt="obraz" src="https://github.com/user-attachments/assets/8ab15eb6-a464-4e57-b03b-78259e1239b5" />