### PR TITLE
Fix for PHP Command for Pint on Windows

### DIFF
--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -38,10 +38,7 @@ const runPintCommand = (
             return;
         }
 
-        const phpPath = getCommand();
-
-        // Without php at the beginning, it won't work on Windows
-        const command = `${phpPath} "${pintPath}" ${args}`.trim();
+        const command = `${getCommand(pintPath)} ${args}`.trim();
 
         cp.exec(
             command,

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -271,8 +271,12 @@ const getHashedFile = (code: string) => {
     return fixFilePath(hashedFile);
 };
 
-export const getCommand = (): string => {
-    return getCommandTemplate().replace('"{code}"', "").trim();
+export const getCommand = (code: string): string => {
+    const commandTemplate = getCommandTemplate();
+
+    return commandTemplate.includes("{code}")
+        ? commandTemplate.replace("{code}", code)
+        : `${commandTemplate} "${code}"`;
 };
 
 export const getCommandTemplate = (): string => {
@@ -287,13 +291,7 @@ export const runPhp = (
         code = "<?php\n\n" + code;
     }
 
-    const commandTemplate = getCommandTemplate();
-
-    const hashedFile = getHashedFile(code);
-
-    const command = commandTemplate.includes("{code}")
-        ? commandTemplate.replace("{code}", hashedFile)
-        : `${commandTemplate} "${hashedFile}"`;
+    const command = getCommand(getHashedFile(code));
 
     return new Promise<string>(function (resolve, error) {
         let result = "";


### PR DESCRIPTION
I'm not 100% sure, but I think that any console php command on Windows requires a path to php at the beginning.

Without this the Pint command doesn't work on Windows.