### PR TITLE
Fix - Replace single quotes with double quotes for echo PHP_BINARY; in phpEnvironments

### DIFF
--- a/src/support/phpEnvironments.ts
+++ b/src/support/phpEnvironments.ts
@@ -42,20 +42,20 @@ export const phpEnvironments: Record<PhpEnvironment, PhpEnvironmentConfig> = {
     },
     lando: {
         label: "Lando",
-        check: "lando php -r 'echo PHP_BINARY;'",
+        check: 'lando php -r "echo PHP_BINARY;"',
         command: "lando php",
         relativePath: true,
     },
     ddev: {
         label: "DDEV",
-        check: "ddev php -r 'echo PHP_BINARY;'",
+        check: 'ddev php -r "echo PHP_BINARY;"',
         command: "ddev php",
         relativePath: true,
     },
     local: {
         label: "Local",
         description: "Use PHP installed on the local machine.",
-        check: "php -r 'echo PHP_BINARY;'",
+        check: 'php -r "echo PHP_BINARY;"',
         command: '"{binaryPath}"',
     },
 };


### PR DESCRIPTION
[Explanation](https://github.com/laravel/vs-code-extension/issues/145#issuecomment-2791456367)

Fix https://github.com/laravel/vs-code-extension/issues/365