### PR TITLE
Internal command: Run PHP Template

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
                     "command": "laravel.namespace.generate",
                     "when": "resourceLangId == php",
                     "group": "laravel"
+                },
+                {
+                    "command": "laravel.internal.runPhpTemplate",
+                    "when": "laravel.inDevMode",
+                    "group": "laravel"
                 }
             ],
             "editor/context": [
@@ -217,6 +222,11 @@
             {
                 "command": "laravel.namespace.generate",
                 "title": "Generate namespace",
+                "category": "Laravel"
+            },
+            {
+                "command": "laravel.internal.runPhpTemplate",
+                "title": "Run PHP Template",
                 "category": "Laravel"
             }
         ],

--- a/src/commands/generatedRegisteredCommands.ts
+++ b/src/commands/generatedRegisteredCommands.ts
@@ -14,4 +14,5 @@ export type RegisteredCommand =
     | "laravel.refactorSelectedHtmlClassToBladeDirective"
     | "laravel.refactorAllHtmlClassesToBladeDirectives"
     | "laravel.namespace.generate"
+    | "laravel.internal.runPhpTemplate"
     | "laravel.open";

--- a/src/commands/runPhpTemplate.ts
+++ b/src/commands/runPhpTemplate.ts
@@ -1,0 +1,25 @@
+import * as vscode from "vscode";
+
+import { type TemplateName, templates } from "@src/templates";
+import { template, runInLaravel } from "@src/support/php";
+
+export const runPhpTemplate = async () => {
+    const selection = await vscode.window.showQuickPick(getChoices(), {
+        placeHolder: "Select the PHP template to run.",
+        canPickMany: false,
+    });
+
+    if (!selection) {
+        return;
+    }
+
+    const output = await runInLaravel(
+        template(selection.label as TemplateName),
+    );
+
+    console.log(output);
+};
+
+const getChoices = (): vscode.QuickPickItem[] => {
+    return Object.keys(templates).map((label) => ({ label }));
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import {
     wrapSelectionCommand,
     wrapWithHelperCommands,
 } from "./commands/wrapWithHelper";
+import { runPhpTemplate } from "./commands/runPhpTemplate";
 import { configAffected } from "./support/config";
 import { collectDebugInfo } from "./support/debug";
 import {
@@ -258,6 +259,17 @@ export async function activate(context: vscode.ExtensionContext) {
             refactorAllHtmlClassesToBladeDirectives,
         ),
     );
+
+    if (context.extensionMode === vscode.ExtensionMode.Development) {
+        vscode.commands.executeCommand("setContext", "laravel.inDevMode", true);
+
+        context.subscriptions.push(
+            vscode.commands.registerCommand(
+                commandName("laravel.internal.runPhpTemplate"),
+                runPhpTemplate,
+            ),
+        );
+    }
 
     collectDebugInfo();
 

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -11,7 +11,7 @@ import routes from "./routes";
 import translations from "./translations";
 import views from "./views";
 
-const templates = {
+export const templates = {
     app,
     auth,
     bladeComponents,


### PR DESCRIPTION
This PR adds a new "Run PHP Template" command that is only available while developing the extension.
It's intended to make debugging the php templates easier during development.

# Demo

![demo](https://github.com/user-attachments/assets/747d9750-b436-4b8d-b522-6a5b74d852c0)


# Implementation details

Visual Studio Code requires commands and command palette entries to be registered in `package.json`.

We only want this command to be visible in development mode. Since none of the existing context keys indicate whether the extension is running in development, we manually add a custom context key:

```tsx
vscode.commands.executeCommand("setContext", "laravel.inDevMode", true);
```

> If you are authoring your own VS Code extension and need to enable/disable commands, menus, or views using a when clause context and none of the existing keys suit your needs, you can add your own context key with the setContext command.

Reference: https://code.visualstudio.com/api/references/when-clause-contexts#add-a-custom-when-clause-context
