### PR TITLE
Fix "app/Modelsdirectory does not exist" error

### DIFF
--- a/php-templates/auth.php
+++ b/php-templates/auth.php
@@ -6,9 +6,11 @@ if (!\Illuminate\Support\Facades\App::bound('auth')) {
         'policies' => (object) [],
     ]);
 } else {
-    collect(\Illuminate\Support\Facades\File::allFiles(base_path('app/Models')))
-        ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
-        ->each(fn($file) => include_once($file));
+    if (\Illuminate\Support\Facades\File::isDirectory(base_path('app/Models'))) {
+        collect(\Illuminate\Support\Facades\File::allFiles(base_path('app/Models')))
+            ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
+            ->each(fn($file) => include_once($file));
+    }
 
     $modelPolicies = collect(get_declared_classes())
         ->filter(fn($class) => is_subclass_of($class, \Illuminate\Database\Eloquent\Model::class))

--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -54,9 +54,11 @@ $models = new class($factory) {
 
     public function all()
     {
-        collect(\Illuminate\Support\Facades\File::allFiles(base_path('app/Models')))
-            ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
-            ->each(fn($file) => include_once($file));
+            if (\Illuminate\Support\Facades\File::isDirectory(base_path('app/Models'))) {
+                collect(\Illuminate\Support\Facades\File::allFiles(base_path('app/Models')))
+                    ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
+                    ->each(fn($file) => include_once($file));
+            }
 
         return collect(get_declared_classes())
             ->filter(fn($class) => is_subclass_of($class, \Illuminate\Database\Eloquent\Model::class))

--- a/src/templates/auth.ts
+++ b/src/templates/auth.ts
@@ -6,9 +6,11 @@ if (!\\Illuminate\\Support\\Facades\\App::bound('auth')) {
         'policies' => (object) [],
     ]);
 } else {
-    collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
-        ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
-        ->each(fn($file) => include_once($file));
+    if (\\Illuminate\\Support\\Facades\\File::isDirectory(base_path('app/Models'))) {
+        collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
+            ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
+            ->each(fn($file) => include_once($file));
+    }
 
     $modelPolicies = collect(get_declared_classes())
         ->filter(fn($class) => is_subclass_of($class, \\Illuminate\\Database\\Eloquent\\Model::class))

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -54,9 +54,11 @@ $models = new class($factory) {
 
     public function all()
     {
-        collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
-            ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
-            ->each(fn($file) => include_once($file));
+            if (\\Illuminate\\Support\\Facades\\File::isDirectory(base_path('app/Models'))) {
+                collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
+                    ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
+                    ->each(fn($file) => include_once($file));
+            }
 
         return collect(get_declared_classes())
             ->filter(fn($class) => is_subclass_of($class, \\Illuminate\\Database\\Eloquent\\Model::class))


### PR DESCRIPTION
There was an oversight in https://github.com/laravel/vs-code-extension/pull/335, which was merged yesterday.

If `app/Models` does not exist, the extension throws `app/Modelsdirectory does not exist...` error.

This PR patches that issue.

For the future: the most reliable way to find all project models would likely be to scan composer's classmap or the entire project (the first option preferred for efficiency).