### PR TITLE
Fix for QuickFix for vscode.Diagnostic.code

### DIFF
--- a/src/codeAction/codeActionProvider.ts
+++ b/src/codeAction/codeActionProvider.ts
@@ -23,11 +23,20 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
     ): vscode.ProviderResult<vscode.CodeAction[]> {
         return Promise.all(
             context.diagnostics
-                .map((diagnostic) =>
-                    providers.map((provider) =>
-                        provider(diagnostic, document, range, token),
-                    ),
-                )
+                .map((diagnostic) => {
+                    const code =
+                        typeof diagnostic.code === "object"
+                            ? diagnostic.code?.value
+                            : diagnostic.code;
+
+                    if (typeof code !== "string") {
+                        return [];
+                    }
+
+                    return providers.map((provider) =>
+                        provider(code, diagnostic, document, range, token),
+                    );
+                })
                 .flat(),
         ).then((actions) => actions.flat());
     }

--- a/src/features/env.ts
+++ b/src/features/env.ts
@@ -192,12 +192,13 @@ export const viteEnvCodeActionProvider: vscode.CodeActionProvider = {
 };
 
 export const codeActionProvider: CodeActionProviderFunction = async (
+    code: string,
     diagnostic: vscode.Diagnostic,
     document: vscode.TextDocument,
     range: vscode.Range | vscode.Selection,
     token: vscode.CancellationToken,
 ): Promise<vscode.CodeAction[]> => {
-    if (diagnostic.code !== "env") {
+    if (code !== "env") {
         return [];
     }
 

--- a/src/features/inertia.ts
+++ b/src/features/inertia.ts
@@ -141,12 +141,13 @@ export const diagnosticProvider = (
 };
 
 export const codeActionProvider: CodeActionProviderFunction = async (
+    code: string,
     diagnostic: vscode.Diagnostic,
     document: vscode.TextDocument,
     range: vscode.Range | vscode.Selection,
     token: vscode.CancellationToken,
 ): Promise<vscode.CodeAction[]> => {
-    if (diagnostic.code !== "inertia") {
+    if (code !== "inertia") {
         return [];
     }
 

--- a/src/features/view.ts
+++ b/src/features/view.ts
@@ -171,12 +171,13 @@ export const diagnosticProvider = (
 };
 
 export const codeActionProvider: CodeActionProviderFunction = async (
+    code: string,
     diagnostic: vscode.Diagnostic,
     document: vscode.TextDocument,
     range: vscode.Range | vscode.Selection,
     token: vscode.CancellationToken,
 ): Promise<vscode.CodeAction[]> => {
-    if (diagnostic.code !== "view") {
+    if (code !== "view") {
         return [];
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import AutocompleteResult from "./parser/AutocompleteResult";
 
 type CodeActionProviderFunction = (
+    code: string,
     diagnostic: vscode.Diagnostic,
     document: vscode.TextDocument,
     range: vscode.Range | vscode.Selection,


### PR DESCRIPTION
Currently the QuickFix option doesn't work for me:

<img width="584" height="134" alt="obraz" src="https://github.com/user-attachments/assets/7c4cc2c2-27fb-412f-8011-fd3b4889d6c5" />

This is because `vscode.Diagnostic.code` can be one of the following:

```ts
/**
* A code or identifier for this diagnostic.
* Should be used for later processing, e.g. when providing {@link CodeActionContext code actions}.
*/
code?: string | number | {
	/**
		* A code or identifier for this diagnostic.
		* Should be used for later processing, e.g. when providing {@link CodeActionContext code actions}.
		*/
	value: string | number;

	/**
		* A target URI to open with more information about the diagnostic error.
		*/
	target: Uri;
};
```

However, the extension currently checks only for a string value (and not a number or an object): https://github.com/laravel/vs-code-extension/blob/main/src/features/env.ts#L200-L202

This PR fixes the issue for the `env`, `view` and `inertia` helpers.
