### PR TITLE
Fix `after` validation rule completion template

### DIFF
--- a/src/completion/Validation.ts
+++ b/src/completion/Validation.ts
@@ -10,8 +10,8 @@ export class Validation implements CompletionProvider {
     private rules = {
         accepted: "accepted",
         active_url: "active_url",
-        after_or_equal: "after_or_equal:${0:date}",
-        after: "after:date",
+        after_or_equal: "after_or_equal:${1:date}",
+        after: "after:${1:date}",
         alpha_dash: "alpha_dash",
         alpha_num: "alpha_num",
         alpha: "alpha",


### PR DESCRIPTION
This fixes the syntax in the completion template for the `after` rule, so the placeholder can properly be overridden by the user.

Also changed the tabstop position in the `after_or_equal` template from `0` to `1` to be aligned with the rest of the validation templates (functionally equivalent in this case, as there's only one placeholder in the template).
