### PR TITLE
Fix: Ensure environment is detected before generating hashed files

### DIFF
--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -250,7 +250,7 @@ export const runInLaravel = <T>(
 };
 
 export const fixFilePath = (path: string) => {
-    if (phpEnvironmentsThatUseRelativePaths.includes(phpEnvKey!)) {
+    if (phpEnvironmentsThatUseRelativePaths.includes(getPhpEnv())) {
         return relativePath(path);
     }
 


### PR DESCRIPTION
It looks like a very subtle bug slipped into our recent update:
https://github.com/laravel/vs-code-extension/pull/469/changes#diff-f9e00425e32725ad2999a1f3a4b785c3efff648130fa15ae3cc1b9aa3f69ce69R294

# Issue

In the previous PR, we changed the order of execution so that `getHashedFile` is called before `getCommandTemplate`.

Previously, `getCommandTemplate` ran first and handled the environment detection.

Now, because `getHashedFile` runs first, it was trying to access the environment (via `phpEnvKey` variable) before it was actually set. This resulted in the template resolving to an absolute path incorrectly.

# The Fix

I've updated `getHashedFile` so it no longer assumes the environment is ready. It now calls `getPhpEnv` directly to ensure the environment is correctly detected and loaded, regardless of the execution order.
