### PR TITLE
Fix Pint not working on DDEV environment

### DIFF
--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -28,8 +28,6 @@ const runPintCommand = (
 ): Promise<string> => {
     return new Promise<string>((resolve, reject) => {
         // Check if pint exists in vendor/bin
-        const pintPath = projectPath("vendor/bin/pint");
-
         if (!projectPathExists("vendor/bin/pint")) {
             const errorMessage =
                 "Pint not found. Make sure Laravel Pint is installed in your project.";
@@ -38,7 +36,7 @@ const runPintCommand = (
             return;
         }
 
-        const command = `${getCommand(pintPath)} ${args}`.trim();
+        const command = `${getCommand("vendor/bin/pint")} ${args}`.trim();
 
         cp.exec(
             command,


### PR DESCRIPTION
Probably fixes https://github.com/laravel/vs-code-extension/issues/533

The latest PR https://github.com/laravel/vs-code-extension/pull/469 added the php command at the beginning of the Pint command. Thanks to this change, the command works on Windows.

However…

In Docker-based environments like DDEV, the command looks like this:

`ddev php /home/yuip/cmsdev/vendor/bin/pint database/seeders/UserSeeder.php`

Every path after `ddev php` should be either relative or absolute **inside the container** (for example: `/var/www/html/vendor/bin/pint`), not an absolute path from the host system (e.g. the WSL Linux filesystem).

This PR removes the absolute path from the Pint command. If I understand correctly we don't need this because we run the command via `cp.exec` using `cwd: getWorkspaceFolders()[0]?.uri?.fsPath`