### PR TITLE
fix: resolve shell substitution errors on Debian/dash systems

### DIFF
--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -6,6 +6,7 @@ import {
     statusBarWorking,
 } from "@src/support/statusBar";
 import * as cp from "child_process";
+import * as os from "os";
 import * as vscode from "vscode";
 import { commandName } from ".";
 import { config } from "../support/config";
@@ -42,6 +43,7 @@ const runPintCommand = (
             command,
             {
                 cwd: getWorkspaceFolders()[0]?.uri?.fsPath,
+                shell: os.platform() === "win32" ? undefined : "/bin/bash",
             },
             (err, stdout, stderr) => {
                 if (err === null) {

--- a/src/support/php.ts
+++ b/src/support/php.ts
@@ -1,6 +1,7 @@
 import { getTemplate, TemplateName } from "@src/templates";
 import * as cp from "child_process";
 import * as fs from "fs";
+import * as os from "os";
 import * as vscode from "vscode";
 import { BoundedFileCache } from "./cache";
 import { config } from "./config";
@@ -298,7 +299,7 @@ export const runPhp = (
 
         const child = cp.spawn(command, {
             cwd: getWorkspaceFolders()[0]?.uri?.fsPath,
-            shell: true,
+            shell: os.platform() === "win32" ? undefined : "/bin/bash",
         });
 
         child.stdout.on("data", (data) => {
@@ -330,6 +331,7 @@ export const artisan = (
             fullCommand,
             {
                 cwd: workspaceFolder,
+                shell: os.platform() === "win32" ? undefined : "/bin/bash",
             },
             (err, stdout, stderr) => {
                 if (err === null) {


### PR DESCRIPTION
## Problem
When editing PHP files on Debian-based systems (including dev containers), the extension throws repeated "Bad substitution" errors in the output log.

This occurs because:
- Debian/Ubuntu use `dash` as `/bin/sh`, not `bash`
- Dash doesn't support bash-style variable substitution syntax
- PHP code containing patterns like `\${$variable}` (common for currency formatting) triggers the error
- The error appears when the extension analyzes PHP files

Example error:
`2026-01-13 08:27:49.807 [error] /bin/sh: 1: Bad substitution`

## Solution
- **parser.ts**: Changed from `exec()` to `execFile()` to bypass shell interpretation entirely
- **php.ts**: Explicitly use `/bin/bash` for `spawn()` and `exec()` on Unix systems
- **pint.ts**: Explicitly use `/bin/bash` for `exec()` on Unix systems

Consistent approach across all files: `undefined` for Windows (let Node choose), `/bin/bash` for Unix.

## Testing
Tested in a Debian 11 dev container with PHP files containing `\${$var}` patterns - errors no longer appear.
