### PR TITLE
Fix Could not open input file: vendor/bin/pint

### DIFF
--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -10,7 +10,11 @@ import * as vscode from "vscode";
 import { commandName } from ".";
 import { config } from "../support/config";
 import { showErrorPopup } from "../support/popup";
-import { getWorkspaceFolders, projectPathExists } from "../support/project";
+import {
+    getWorkspaceFolders,
+    projectPath,
+    projectPathExists,
+} from "../support/project";
 
 export const pintCommands = {
     all: commandName("laravel.pint.run"),
@@ -37,7 +41,7 @@ const runPintCommand = (
         cp.exec(
             command,
             {
-                cwd: getWorkspaceFolders()[0]?.uri?.fsPath,
+                cwd: projectPath(),
             },
             (err, stdout, stderr) => {
                 if (err === null) {


### PR DESCRIPTION
Potential fix https://github.com/laravel/vs-code-extension/issues/547

## Problem explanation:

The PR https://github.com/laravel/vs-code-extension/pull/469 added the php command at the beginning of the Pint command. Thanks to this change, the command works on Windows.

The PR https://github.com/laravel/vs-code-extension/pull/536 removed the absolute path from the Pint command. Thanks to this change, the command works on DDEV.

### New problem:

Some users, like those mentioned in https://github.com/laravel/vs-code-extension/issues/547 do not use VSCode workspaces, instead, they use the `Laravel.basePath` config. However the `cwd` in [this line](https://github.com/laravel/vs-code-extension/blob/main/src/commands/pint.ts#L40) supports only the workspace path.

This PR replaces the workspace path to the `projectPath` which includes the `Laravel.basePath` config.

I've tested this using Docker in `dev-container` mode and natively under Windows. Unfortunately, I can't test DDEV and other envs :/
