### PR TITLE
Fix namespaced Blade components

### DIFF
--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -48,7 +48,7 @@ $livewire = new class {
                 ]);
             })
             ->whereNotNull()
-            ->unique('path')
+            ->unique('key')
             ->values();
     }
 

--- a/src/templates/views.ts
+++ b/src/templates/views.ts
@@ -48,7 +48,7 @@ $livewire = new class {
                 ]);
             })
             ->whereNotNull()
-            ->unique('path')
+            ->unique('key')
             ->values();
     }
 


### PR DESCRIPTION
## Summary

This PR changes the uniqueness criteria for components from path to key.

## The Problem

Previously, PR #549 enforced uniqueness based on the component's file `path`. However, a single component file can be registered under multiple keys (e.g., both `components.alert` and `alert` might point to the same file). Using the path as the unique identifier caused logic errors when handling these aliased components.

# The Fix

Components are now keyed by their unique identifier (`key`) instead of their file `path`, ensuring that different aliases for the same file are treated as distinct entries where necessary.