### PR TITLE
Improve Livewire 4 component and namespace parsing

### DIFF
--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -3,7 +3,6 @@
 $livewire = new class {
     protected $namespaces;
     protected $paths;
-    protected $extensions;
 
     public function __construct()
     {
@@ -15,11 +14,6 @@ $livewire = new class {
             ->merge(config("livewire.component_locations", []))
             ->unique()
             ->map(LaravelVsCode::relativePath(...));
-
-        $this->extensions = array_map(
-            fn($extension) => ".{$extension}",
-            app('view')->getExtensions(),
-        );
     }
 
     public function parse(\Illuminate\Support\Collection $views)
@@ -92,7 +86,7 @@ $livewire = new class {
         $file = str($view["path"])
             ->replace("⚡", "")
             ->basename()
-            ->beforeLast(".blade.php");
+            ->replace([".blade.php", ".php", ".js", ".global.css", ".css", ".test.php"], "");
 
         $class = str($view["path"])
             ->dirname()

--- a/src/templates/views.ts
+++ b/src/templates/views.ts
@@ -3,7 +3,6 @@ export default `
 $livewire = new class {
     protected $namespaces;
     protected $paths;
-    protected $extensions;
 
     public function __construct()
     {
@@ -15,11 +14,6 @@ $livewire = new class {
             ->merge(config("livewire.component_locations", []))
             ->unique()
             ->map(LaravelVsCode::relativePath(...));
-
-        $this->extensions = array_map(
-            fn($extension) => ".{$extension}",
-            app('view')->getExtensions(),
-        );
     }
 
     public function parse(\\Illuminate\\Support\\Collection $views)
@@ -92,7 +86,7 @@ $livewire = new class {
         $file = str($view["path"])
             ->replace("⚡", "")
             ->basename()
-            ->beforeLast(".blade.php");
+            ->replace([".blade.php", ".php", ".js", ".global.css", ".css", ".test.php"], "");
 
         $class = str($view["path"])
             ->dirname()


### PR DESCRIPTION
This PR simplifies key parsing for Livewire 4 components.

Potentially fixes https://github.com/laravel/vs-code-extension/issues/555

# Example

Let's look at a slightly more complex example: an MFC Livewire component that uses a custom Livewire namespace and a custom Blade namespace.

```
resources/
└── views/
    └── livewire/
        └── ui/
            └── button/
                ├── button.blade.php
                └── button.php
```

`app/Provides/AppServiceProvider.php`
```php
/**
 * Bootstrap any application services.
 */
public function boot(): void
{
    $this->loadViewsFrom(resource_path('views/livewire/ui'), 'ui');
}

```

`config/livewire.php`
```php
'component_namespaces' => [
    'custom' => resource_path('views/livewire/ui'),
],
```

### Result

The extension would generate the following view keys:

| Key | Description |
| :--- | :--- |
| `livewire.ui.button.button` | Path to the **Blade view** |
| `ui::button.button` | Path to the **namespaced Blade view** |
| `ui.button` | Path to the **Livewire component** |
| `custom::button` | Path to the **namespaced Livewire component** |

Note: This works with the ⚡ emoji too!