### PR TITLE
Add missing semicolons to markdown props

### DIFF
--- a/src/support/markdown.ts
+++ b/src/support/markdown.ts
@@ -13,6 +13,7 @@ export const appendProps = (
         [
             `${prop.type} \$${prop.name}`,
             prop.hasDefaultValue ? ` = ${prop.defaultValue}` : "",
+            ";",
         ].join(""),
     );
 


### PR DESCRIPTION
<img width="476" height="223" alt="Screenshot 2026-01-26 at 22 27 34" src="https://github.com/user-attachments/assets/24a9fc4b-75dd-4be5-8354-61953b81e45d" />
