### PR TITLE
Livewire 4: Better MFC Support

### DIFF
--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -3,6 +3,7 @@
 $livewire = new class {
     protected $namespaces;
     protected $paths;
+    protected $extensions = [".blade.php", ".php", ".js", ".global.css", ".css", ".test.php"];
 
     public function __construct()
     {
@@ -35,7 +36,9 @@ $livewire = new class {
                     return $view;
                 }
 
-                if ($this->isMfc($view) && str($view['path'])->doesntEndWith('.blade.php')) {
+                $files = $this->files($view);
+
+                if (count($files) === 1 && str($view['path'])->doesntEndWith('.blade.php')) {
                     return null;
                 }
 
@@ -43,6 +46,7 @@ $livewire = new class {
                     "key" => $key,
                     'livewire' => [
                         'props' => $this->getProps($component),
+                        'files' => $files,
                     ],
                 ]);
             })
@@ -67,6 +71,7 @@ $livewire = new class {
             return array_merge($view, [
                 'livewire' => [
                     'props' => $this->getProps($component),
+                    'files' => [$view['path']],
                 ],
             ]);
         });
@@ -119,6 +124,20 @@ $livewire = new class {
             ->value();
     }
 
+    protected function files(array $view): array
+    {
+        if (! $this->isMfc($view)) {
+            return [$view['path']];
+        }
+
+        $filePathWithoutExtension = str($view["path"])->replace($this->extensions, "");
+
+        return collect($this->extensions)
+            ->map(fn (string $extension) => $filePathWithoutExtension->append($extension))
+            ->filter(fn (string $path) => \Illuminate\Support\Facades\File::exists($path))
+            ->all();
+    }
+
     protected function isMfc(array $view): bool
     {
         $directory = str($view["path"])
@@ -129,7 +148,7 @@ $livewire = new class {
         $file = str($view["path"])
             ->replace("⚡", "")
             ->basename()
-            ->replace([".blade.php", ".php", ".js", ".global.css", ".css", ".test.php"], "");
+            ->replace($this->extensions, "");
 
         $class = str($view["path"])
             ->dirname()

--- a/src/features/livewireComponent.ts
+++ b/src/features/livewireComponent.ts
@@ -62,7 +62,9 @@ export const hoverProvider: HoverProvider = (
         .replace("/", "")
         .replace("livewire:", "");
 
-    const view = views.find((view) => view.key === match);
+    const view = views.find((v) => {
+        return v.key === `livewire.${match}` || (v.livewire && v.key === match);
+    });
 
     if (!view || !view.livewire) {
         return null;
@@ -70,9 +72,11 @@ export const hoverProvider: HoverProvider = (
 
     const markdown = new vscode.MarkdownString();
 
-    markdown.appendMarkdown(
-        `[${view.path}](${vscode.Uri.file(projectPath(view.path))})`,
-    );
+    const files = view.livewire.files.map((path) => {
+        return `[${path}](${vscode.Uri.file(projectPath(path))})`;
+    });
+
+    markdown.appendMarkdown(files.join("\n\n"));
 
     appendProps(markdown, view.livewire.props);
 

--- a/src/repositories/views.ts
+++ b/src/repositories/views.ts
@@ -13,6 +13,7 @@ export interface ViewItem {
             hasDefaultValue: boolean;
             defaultValue: string;
         }[];
+        files: string[];
     };
 }
 

--- a/src/support/markdown.ts
+++ b/src/support/markdown.ts
@@ -9,6 +9,10 @@ export const appendProps = (
         defaultValue: string;
     }[],
 ) => {
+    if (props.length === 0) {
+        return;
+    }
+
     const result = props.map((prop) =>
         [
             `${prop.type} \$${prop.name}`,


### PR DESCRIPTION
This PR displays all MFC files on hover:

<img width="497" height="261" alt="Screenshot 2026-01-29 at 12 04 08" src="https://github.com/user-attachments/assets/fbbba5f9-04b9-400d-8cff-0f3d292ea95c" />

Besides that there are a few smaller fixes:

- Fixes hover cards for Livewire 3 components.
- Does not display the props codeblock in hover card if there are no props.