### PR TITLE
Fix: Method Illuminate\Support\Stringable::doesntEndWith does not exist.

### DIFF
--- a/php-templates/blade-components.php
+++ b/php-templates/blade-components.php
@@ -335,7 +335,7 @@ $components = new class {
                     return $component;
                 }
 
-                if (str($component['path'])->doesntEndWith('.blade.php')) {
+                if (!str($component['path'])->endsWith('.blade.php')) {
                     return $component;
                 }
 

--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -38,7 +38,7 @@ $livewire = new class {
 
                 $files = $this->files($view);
 
-                if (count($files) === 1 && str($view['path'])->doesntEndWith('.blade.php')) {
+                if (count($files) === 1 && !str($view['path'])->endsWith('.blade.php')) {
                     return null;
                 }
 
@@ -58,7 +58,7 @@ $livewire = new class {
     protected function parseLivewireThree(\Illuminate\Support\Collection $views)
     {
         return $views->map(function (array $view) {
-            if (str($view['key'])->doesntStartWith('livewire.')) {
+            if (!str($view['key'])->startsWith('livewire.')) {
                 return $view;
             }
 

--- a/src/templates/blade-components.ts
+++ b/src/templates/blade-components.ts
@@ -335,7 +335,7 @@ $components = new class {
                     return $component;
                 }
 
-                if (str($component['path'])->doesntEndWith('.blade.php')) {
+                if (!str($component['path'])->endsWith('.blade.php')) {
                     return $component;
                 }
 

--- a/src/templates/views.ts
+++ b/src/templates/views.ts
@@ -38,7 +38,7 @@ $livewire = new class {
 
                 $files = $this->files($view);
 
-                if (count($files) === 1 && str($view['path'])->doesntEndWith('.blade.php')) {
+                if (count($files) === 1 && !str($view['path'])->endsWith('.blade.php')) {
                     return null;
                 }
 
@@ -58,7 +58,7 @@ $livewire = new class {
     protected function parseLivewireThree(\\Illuminate\\Support\\Collection $views)
     {
         return $views->map(function (array $view) {
-            if (str($view['key'])->doesntStartWith('livewire.')) {
+            if (!str($view['key'])->startsWith('livewire.')) {
                 return $view;
             }
 


### PR DESCRIPTION
Fix compatibility with Laravel < 12

Replaced usage of Stringable::doesntEndWith(), which is only available in Laravel 12.

<img width="1032" height="547" alt="image" src="https://github.com/user-attachments/assets/2a188cea-7ba0-4b18-af37-b24f8cdf0dbb" />
