### PR TITLE
Fix props without types

### DIFF
--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -104,7 +104,7 @@ $livewire = new class {
 
             return [
                 'name' => $prop,
-                'type' => $reflection->getType()->getName(),
+                'type' => $reflection->getType()?->getName() ?? 'mixed',
                 'hasDefaultValue' => $reflection->hasDefaultValue(),
                 'defaultValue' => $this->formatDefaultValue($reflection->getDefaultValue()),
             ];

--- a/src/templates/views.ts
+++ b/src/templates/views.ts
@@ -104,7 +104,7 @@ $livewire = new class {
 
             return [
                 'name' => $prop,
-                'type' => $reflection->getType()->getName(),
+                'type' => $reflection->getType()?->getName() ?? 'mixed',
                 'hasDefaultValue' => $reflection->hasDefaultValue(),
                 'defaultValue' => $this->formatDefaultValue($reflection->getDefaultValue()),
             ];


### PR DESCRIPTION
This PR handles cases where props are missing a defined type by having them fall back to the mixed type.

Fixes: https://github.com/laravel/vs-code-extension/issues/562