### PR TITLE
Add comprehensive support for composite, union, and special PHP types

### DIFF
--- a/php-templates/views.php
+++ b/php-templates/views.php
@@ -104,7 +104,7 @@ $livewire = new class {
 
             return [
                 'name' => $prop,
-                'type' => $reflection->getType()?->getName() ?? 'mixed',
+                'type' => (string) $reflection->getType() ?: 'mixed',
                 'hasDefaultValue' => $reflection->hasDefaultValue(),
                 'defaultValue' => $this->formatDefaultValue($reflection->getDefaultValue()),
             ];

--- a/src/templates/views.ts
+++ b/src/templates/views.ts
@@ -104,7 +104,7 @@ $livewire = new class {
 
             return [
                 'name' => $prop,
-                'type' => $reflection->getType()?->getName() ?? 'mixed',
+                'type' => (string) $reflection->getType() ?: 'mixed',
                 'hasDefaultValue' => $reflection->hasDefaultValue(),
                 'defaultValue' => $this->formatDefaultValue($reflection->getDefaultValue()),
             ];


### PR DESCRIPTION
This PR expands the extension's type handling capabilities beyond basic scalar types. It introduces full support for modern PHP 8.0+ type systems, including Union types, Intersection types and DNF types.

<img width="492" height="227" alt="Screenshot 2026-01-30 at 08 29 59" src="https://github.com/user-attachments/assets/94f8476a-8f15-4e10-9b14-21e0921fe5f8" />
