### PR TITLE
Fix error thrown by non-instantiable (abstract) policy classes

### DIFF
--- a/php-templates/auth.php
+++ b/php-templates/auth.php
@@ -18,6 +18,7 @@ if (!\Illuminate\Support\Facades\App::bound('auth')) {
             \Illuminate\Database\Eloquent\Relations\Pivot::class,
             \Illuminate\Foundation\Auth\User::class,
         ]))
+		->filter(fn($class) => (new \ReflectionClass($class))->isInstantiable())
         ->flatMap(fn($class) => [
             $class => \Illuminate\Support\Facades\Gate::getPolicyFor($class),
         ])

--- a/src/templates/auth.ts
+++ b/src/templates/auth.ts
@@ -18,6 +18,7 @@ if (!\\Illuminate\\Support\\Facades\\App::bound('auth')) {
             \\Illuminate\\Database\\Eloquent\\Relations\\Pivot::class,
             \\Illuminate\\Foundation\\Auth\\User::class,
         ]))
+		->filter(fn($class) => (new \\ReflectionClass($class))->isInstantiable())
         ->flatMap(fn($class) => [
             $class => \\Illuminate\\Support\\Facades\\Gate::getPolicyFor($class),
         ])


### PR DESCRIPTION
I was getting the below error when using an abstract model class with a corresponding abstract policy class.

```
2026-02-06 11:02:24.639 [error] Auth Data

Error: __VSCODE_LARAVEL_START_OUTPUT__
   Illuminate\Contracts\Container\BindingResolutionException 

  Target [App\Policies\Abstracts\AbstractAdminRolePolicy] is not instantiable.

  at vendor/laravel/framework/src/Illuminate/Container/Container.php:1411
    1407▕         } else {
    1408▕             $message = "Target [$concrete] is not instantiable.";
    1409▕         }
    1410▕ 
  ➜ 1411▕         throw new BindingResolutionException($message);
    1412▕     }
    1413▕ 
    1414▕     /**
    1415▕      * Throw an exception for an unresolvable primitive.
```

This PR fixes the error by filtering out non-instantiable model classes before getting the model policies. It still correctly picks up the policies for the concrete classes that make use of the abstract ones.