### PR TITLE
Fix ReflectionException when policy method does not exist

### DIFF
--- a/php-templates/auth.php
+++ b/php-templates/auth.php
@@ -78,10 +78,12 @@ if (!\Illuminate\Support\Facades\App::bound('auth')) {
                                 if (get_class($closureThis) === \Illuminate\Auth\Access\Gate::class) {
                                     $vars = $reflection->getClosureUsedVariables();
 
-                                    if (isset($vars['callback'])) {
+                                    if (isset($vars['callback']) && str_contains($vars['callback'], '@')) {
                                         [$policyClass, $method] = explode('@', $vars['callback']);
 
-                                        $reflection = new \ReflectionMethod($policyClass, $method);
+                                        if (method_exists($policyClass, $method)) {
+                                            $reflection = new \ReflectionMethod($policyClass, $method);
+                                        }
                                     }
                                 }
                             }

--- a/src/templates/auth.ts
+++ b/src/templates/auth.ts
@@ -78,10 +78,12 @@ if (!\\Illuminate\\Support\\Facades\\App::bound('auth')) {
                                 if (get_class($closureThis) === \\Illuminate\\Auth\\Access\\Gate::class) {
                                     $vars = $reflection->getClosureUsedVariables();
 
-                                    if (isset($vars['callback'])) {
+                                    if (isset($vars['callback']) && str_contains($vars['callback'], '@')) {
                                         [$policyClass, $method] = explode('@', $vars['callback']);
 
-                                        $reflection = new \\ReflectionMethod($policyClass, $method);
+                                        if (method_exists($policyClass, $method)) {
+                                            $reflection = new \\ReflectionMethod($policyClass, $method);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
When discovering gate abilities, the extension calls `ReflectionMethod` on the policy class and method extracted from the gate's closure variables. This throws a `ReflectionException` if the method doesn't actually exist on the policy class.

This can happen when `Gate::resource()` is called with an empty abilities array — since `[]` is falsy in PHP, Laravel falls back to its default abilities (`viewAny`, `view`, `create`, `update`, `delete`), even if the policy only defines custom methods.

Related: #343, #165, #506