### PR TITLE
Improve Test Runner error parsing

### DIFF
--- a/src/test-runner/teamcity.ts
+++ b/src/test-runner/teamcity.ts
@@ -47,14 +47,21 @@ export const buildErrorMessage = (event: TeamcityEvent): vscode.TestMessage => {
         return message;
     }
 
-    const lastColonIndex = details.lastIndexOf(":");
+    const lines = details.split("\n").filter((line) => line.trim());
+    const lastLine = lines[lines.length - 1];
+
+    if (!lastLine) {
+        return message;
+    }
+
+    const lastColonIndex = lastLine.lastIndexOf(":");
 
     if (lastColonIndex === -1) {
         return message;
     }
 
-    const file = details.substring(0, lastColonIndex);
-    const line = parseInt(details.substring(lastColonIndex + 1), 10);
+    const file = lastLine.substring(0, lastColonIndex);
+    const line = parseInt(lastLine.substring(lastColonIndex + 1), 10);
 
     if (isNaN(line)) {
         return message;


### PR DESCRIPTION
Previously, stack traces with multiple files would show the wrong location. Now we parse the last entry in the stack trace, which is the actual line in your test where the failure occurred.

Example: error happening in the `EmailVerificationPromptController` but shows correctly in the test:

<img width="805" height="307" alt="Screenshot 2026-02-12 at 16 56 38" src="https://github.com/user-attachments/assets/a7da92b7-6043-40e6-8216-d7062773def0" />
