### PR TITLE
Fix newline in the Blade class component hover

### DIFF
--- a/src/features/bladeComponent.ts
+++ b/src/features/bladeComponent.ts
@@ -1,6 +1,7 @@
 import { getBladeComponents } from "@src/repositories/bladeComponents";
 import { config } from "@src/support/config";
 import { projectPath } from "@src/support/project";
+import os from "os";
 import * as vscode from "vscode";
 import { HoverProvider, LinkProvider } from "..";
 
@@ -139,6 +140,7 @@ export const hoverProvider: HoverProvider = (
                         "`" + prop.type + "` ",
                         "`" + prop.name + "`",
                         prop.default ? ` = ${prop.default}` : "",
+                        os.EOL.repeat(2),
                     ].join(""),
                 ),
             );


### PR DESCRIPTION
Example Blade class component:

```php
<?php

namespace App\View\Components;

use Illuminate\Contracts\View\View;
use Illuminate\View\Component;

class ExampleComponent extends Component
{
    public function __construct(
        public string $title,
        public array $description,
    ) {}

    public function render(): View
    {
        return view('components.example-component');
    }
}
```

Before:

<img width="554" height="240" alt="obraz" src="https://github.com/user-attachments/assets/1e1b1c9f-ab4b-451c-a35a-a8a327c89ea9" />

After:

<img width="606" height="292" alt="obraz" src="https://github.com/user-attachments/assets/04fc991a-8af3-47be-aced-e251b2907aad" />
