### PR TITLE
Discover tests on activation

### DIFF
--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -27,5 +27,7 @@ export const registerTestRunner = async (): Promise<vscode.TestController> => {
         updateExplorer(controller);
     });
 
+    updateExplorer(controller);
+
     return controller;
 };


### PR DESCRIPTION
Tests are now discovered automatically when the extension activates, rather than waiting for the user to open the test explorer. This makes tests immediately available for running from the command palette or inline run buttons.