### PR TITLE
Fix error location resolution for Docker/Sail environments

### DIFF
--- a/src/test-runner/teamcity.ts
+++ b/src/test-runner/teamcity.ts
@@ -1,4 +1,6 @@
 import * as vscode from "vscode";
+import { getPaths } from "@src/repositories/paths";
+import { projectPath } from "@src/support/project";
 
 export interface TeamcityEvent {
     type: string;
@@ -60,7 +62,7 @@ export const buildErrorMessage = (event: TeamcityEvent): vscode.TestMessage => {
         return message;
     }
 
-    const file = lastLine.substring(0, lastColonIndex);
+    const file = resolveToHostPath(lastLine.substring(0, lastColonIndex));
     const line = parseInt(lastLine.substring(lastColonIndex + 1), 10);
 
     if (isNaN(line)) {
@@ -73,4 +75,16 @@ export const buildErrorMessage = (event: TeamcityEvent): vscode.TestMessage => {
     );
 
     return message;
+};
+
+const resolveToHostPath = (containerPath: string): string => {
+    const basePath = getPaths().items.find(
+        (item) => item.key === "base_path",
+    )?.path;
+
+    if (basePath && containerPath.startsWith(basePath)) {
+        return projectPath(containerPath.slice(basePath.length + 1));
+    }
+
+    return containerPath;
 };


### PR DESCRIPTION
## The Problem

When you run tests inside Docker or Sail, the stack traces use container paths (like `/var/www/html/tests/ExampleTest.php`). Since those paths don't exist on your host machine, the 'Go to error' button in VS Code's test explorer does not work.

## The Fix

I'm using the `getPaths` repository to grab the Laravel `base_path` directly from the container.
The extension now strips that container prefix and replaces it with your local workspace path.

## Example

Before: `/var/www/html/tests/Feature/ExampleTest.php`
After: `/Users/name/project/tests/Feature/ExampleTest.php`

## What's Next?

I'm looking into creating a global helper to handle these environment-to-local path conversions. There's already a `pathForPhpEnv` stub in the codebase, but I want to make sure implementing it won't cause any weird side effects before I go all in on it.