### PR TITLE
Support for XDebug trigger mode for Test Runner

### DIFF
--- a/src/test-runner/runner.ts
+++ b/src/test-runner/runner.ts
@@ -99,8 +99,8 @@ const isPhpDebugEnabled = (): boolean =>
     vscode.debug.activeDebugSession?.type === "php";
 
 const getProcessEnv = (): NodeJS.ProcessEnv => ({
-    ...process.env,
     ...(isPhpDebugEnabled() ? { XDEBUG_TRIGGER: "1" } : {}),
+    ...process.env,
 });
 
 const executeTests = async (


### PR DESCRIPTION
This PR adds the ability to run tests using the runner with Xdebug support (for breakpoints) in `trigger` mode. Example:

https://github.com/user-attachments/assets/a0eeb9a1-34c6-429c-9b7d-0fde6649df28

