### PR TITLE
Fix for Test Runner FileWatcher

### DIFF
--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 
 import { config } from "@src/support/config";
-import { createFileWatcher, inAppDirs } from "@src/support/fileWatcher";
-import { projectPath } from "@src/support/project";
+import { createFileWatcher } from "@src/support/fileWatcher";
 import { updateExplorer } from "./explorer";
 import { runHandler } from "./runner";
 


### PR DESCRIPTION
Currently, the FileWatcher for test files doesn’t work at all because the pattern is incorrect and events are missing.

This PR fixes the issue.