### PR TITLE
Fix component and view discovery fails with symlinked packages outside project directory

### DIFF
--- a/php-templates/bootstrap-laravel.php
+++ b/php-templates/bootstrap-laravel.php
@@ -10,11 +10,38 @@ class LaravelVsCode
 {
     public static function relativePath($path)
     {
-        if (!str_contains($path, base_path())) {
-            return (string) $path;
+        if (! str_contains($path, base_path())) {
+            return self::relativePathBySegmentComparison($path);
         }
 
         return ltrim(str_replace(base_path(), '', realpath($path) ?: $path), DIRECTORY_SEPARATOR);
+    }
+
+    public static function relativePathBySegmentComparison(string $path): string
+    {
+        $realPath = realpath($path);
+
+        if (! $realPath) {
+            return $path;
+        }
+
+        $splitRealPath = explode(DIRECTORY_SEPARATOR, $realPath);
+        $splitBasePath = explode(DIRECTORY_SEPARATOR, base_path());
+
+        $diff = array_diff_assoc($splitRealPath, $splitBasePath);
+
+        $firstMissingSegmentIndex = array_key_first($diff);
+
+        // If the first segment is different, this path is likely on a different drive (Windows), so return the original path.
+        if ($firstMissingSegmentIndex === 0 || $firstMissingSegmentIndex === null) {
+            return $path;
+        }
+
+        array_splice($splitRealPath, 0, $firstMissingSegmentIndex);
+
+        $missingSegments = count($splitBasePath) - $firstMissingSegmentIndex;
+
+        return str_repeat('..'.DIRECTORY_SEPARATOR, $missingSegments).implode(DIRECTORY_SEPARATOR, $splitRealPath);
     }
 
     public static function isVendor($path)

--- a/src/templates/bootstrap-laravel.ts
+++ b/src/templates/bootstrap-laravel.ts
@@ -10,11 +10,38 @@ class LaravelVsCode
 {
     public static function relativePath($path)
     {
-        if (!str_contains($path, base_path())) {
-            return (string) $path;
+        if (! str_contains($path, base_path())) {
+            return self::relativePathBySegmentComparison($path);
         }
 
         return ltrim(str_replace(base_path(), '', realpath($path) ?: $path), DIRECTORY_SEPARATOR);
+    }
+
+    public static function relativePathBySegmentComparison(string $path): string
+    {
+        $realPath = realpath($path);
+
+        if (! $realPath) {
+            return $path;
+        }
+
+        $splitRealPath = explode(DIRECTORY_SEPARATOR, $realPath);
+        $splitBasePath = explode(DIRECTORY_SEPARATOR, base_path());
+
+        $diff = array_diff_assoc($splitRealPath, $splitBasePath);
+
+        $firstMissingSegmentIndex = array_key_first($diff);
+
+        // If the first segment is different, this path is likely on a different drive (Windows), so return the original path.
+        if ($firstMissingSegmentIndex === 0 || $firstMissingSegmentIndex === null) {
+            return $path;
+        }
+
+        array_splice($splitRealPath, 0, $firstMissingSegmentIndex);
+
+        $missingSegments = count($splitBasePath) - $firstMissingSegmentIndex;
+
+        return str_repeat('..'.DIRECTORY_SEPARATOR, $missingSegments).implode(DIRECTORY_SEPARATOR, $splitRealPath);
     }
 
     public static function isVendor($path)


### PR DESCRIPTION
Fixes [https://github.com/laravel/vs-code-extension/issues/575](https://github.com/laravel/vs-code-extension/issues/575)

### Current behaviour

`LaravelVsCode::relativePath` generates a relative path by removing the Laravel project's `basePath` from the given path. However, if the path does not contain the `basePath` (for example, when it points to a location outside the project directory), the result is the absolute path within the repository for that view/component.

### My proposition

As a fallback in this situation, `LaravelVsCode::relativePath` could use another method based on segment comparison.

**Windows example:**

BasePath: `D:\Work\livewire-starter-kit`

ViewPath: `D:\Work\packages\author-name\package-name\resources\views\hello.blade.php`

`D:\Work` is the common part, so it can be removed. The `livewire-starter-kit` segment is missing in the view path, which means we need to go up one level (`..`).

The final relative path would be:

`..\packages\author-name\package-name\resources\views\hello.blade.php`