### PR TITLE
Fix parsing of PHP code containing special characters

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -108,6 +108,8 @@ const downloadBinary = async (context: vscode.ExtensionContext) => {
 };
 
 const cleanArg = (arg: string): string => {
+    arg = arg.replace(/;;/g, ";");
+
     if (os.platform() === "win32") {
         const tempFile = tempPath(md5(arg));
 
@@ -117,25 +119,6 @@ const cleanArg = (arg: string): string => {
 
         return tempFile;
     }
-
-    const replacements: [string | RegExp, string][] = [[/;;/g, ";"]];
-
-    if (
-        ["linux", "openbsd", "sunos", "darwin"].some((unixPlatforms) =>
-            os.platform().includes(unixPlatforms),
-        )
-    ) {
-        replacements.push([/\$/g, "\\$"]);
-        replacements.push([/\\'/g, "\\\\'"]);
-        replacements.push([/\\"/g, '\\\\"']);
-    }
-
-    replacements.push([/\"/g, '\\"']);
-    replacements.push([/\`/g, "\\`"]);
-
-    replacements.forEach((replacement) => {
-        arg = arg.replace(replacement[0], replacement[1]);
-    });
 
     return arg;
 };
@@ -151,7 +134,7 @@ export const detect = async (
         >;
     }
 
-    const promise = runCommand(`detect "${cleanArg(code)}"`)
+    const promise = runCommand("detect", [cleanArg(code)])
         .then((result: string) => {
             return result.length > 0 ? JSON.parse(result) : result;
         })
@@ -164,7 +147,7 @@ export const detect = async (
     return promise;
 };
 
-const runCommand = (command: string): Promise<string> => {
+const runCommand = (command: string, args: string[]): Promise<string> => {
     return new Promise(async function (resolve, reject) {
         if (!parserBinaryPath) {
             const waitForPath = async () => {
@@ -180,13 +163,13 @@ const runCommand = (command: string): Promise<string> => {
             await waitForPath();
         }
 
-        const extraArgs = os.platform() === "win32" ? "--from-file" : "";
-        const toRun = `"${parserBinaryPath}" ${command} ${extraArgs}`;
+        if (os.platform() === "win32") {
+            args.push("--from-file");
+        }
 
-        // console.log("running command", toRun);
-
-        cp.exec(
-            toRun,
+        cp.execFile(
+            parserBinaryPath!,
+            [command, ...args],
             {
                 cwd: __dirname,
                 timeout: 5000,
@@ -214,7 +197,7 @@ export const parseForAutocomplete = (
 
     const arg = cleanArg(code);
 
-    const promise = runCommand(`autocomplete "${arg}"`)
+    const promise = runCommand("autocomplete", [arg])
         .then((result: string) => {
             return new AutocompleteResult(JSON.parse(result));
         })

--- a/src/test/fixtures/laravel-react/app/parser-special-chars.php
+++ b/src/test/fixtures/laravel-react/app/parser-special-chars.php
@@ -1,0 +1,8 @@
+<?php
+
+$variable = "value";
+$nested = "{$variable}_suffix";
+$complex = "{$variable}_end";
+$backtick = `whoami`;
+
+config('app.name');

--- a/src/test/parser-special-chars.test.ts
+++ b/src/test/parser-special-chars.test.ts
@@ -1,0 +1,19 @@
+import * as vscode from "vscode";
+import { assertCompletions } from "./assertions";
+import { activateExtension, uri } from "./helper";
+
+suite("Parser Special Characters Test Suite", () => {
+    suiteSetup(async () => {
+        await activateExtension();
+    });
+
+    test("parses code with shell metacharacters without errors", async () => {
+        await assertCompletions({
+            doc: await vscode.workspace.openTextDocument(
+                uri("app/parser-special-chars.php"),
+            ),
+            lines: ["config('app.name');"],
+            expects: ["app.name"],
+        });
+    });
+});


### PR DESCRIPTION
Switch the PHP parser from `cp.exec` (shell) to `cp.execFile` (no shell), so that PHP code containing special characters like `$variables`, backticks, or quotes is passed directly to the parser binary without going through the shell. 

This eliminates an entire class of bugs where the shell would interpret characters in the code before the parser ever saw them, and removes the need for fragile platform-specific escaping logic.