### PR TITLE
Test case for intermediate config keys

### DIFF
--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -37,6 +37,10 @@ suite("Config Test Suite", () => {
                     line: "Config::get('filesystems.default');",
                     target: "config/filesystems.php",
                 },
+                {
+                    line: "config('database.connections');",
+                    target: "config/database.php",
+                },
             ],
         });
     });
@@ -50,6 +54,10 @@ suite("Config Test Suite", () => {
                 {
                     line: "config('app.name');",
                     contains: ["config/app"],
+                },
+                {
+                    line: "config('database.connections');",
+                    contains: ["config/database"],
                 },
             ],
         });

--- a/src/test/fixtures/laravel-react/app/config-helper.php
+++ b/src/test/fixtures/laravel-react/app/config-helper.php
@@ -5,4 +5,5 @@ use Illuminate\Support\Facades\Config;
 config('app.name');
 config('filesystems.default');
 Config::get('filesystems.default');
+config('database.connections');
 config('missing-config.entry');


### PR DESCRIPTION
This PR adds a test case that intermediate config keys like ´config('database.connections')` should produce clickable links, hovers, and no false diagnostics.