### PR TITLE
Increase binary download timeout to 5 minutes

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -87,7 +87,7 @@ const downloadBinary = async (context: vscode.ExtensionContext) => {
             undefined,
             undefined,
             {
-                timeoutInMs: 60_000,
+                timeoutInMs: 300_000,
             },
         );
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the download timeout setting in the `downloadBinary` function. The change increases the timeout value to allow more time for downloads to complete, which should help prevent premature failures during slower network conditions. https://github.com/laravel/vs-code-extension/issues/544