### PR TITLE
Disable error popups by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -752,7 +752,7 @@
                 },
                 "Laravel.showErrorPopups": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Show popups for errors."
                 },
                 "Laravel.env.viteQuickFix": {


### PR DESCRIPTION
Error popups are now opt-in rather than opt-out. Previously, the `showErrorPopups` setting defaulted to `true`, which meant users would see error notification popups for any issue, including syntax errors in their own code.

This changes the default to `false` so popups are suppressed unless a user explicitly enables them.