### PR TITLE
Debounce Pint processes on save

### DIFF
--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -16,6 +16,9 @@ import {
     projectPathExists,
 } from "../support/project";
 
+let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+let runningProcess: cp.ChildProcess | undefined;
+
 export const pintCommands = {
     all: commandName("laravel.pint.run"),
     currentFile: commandName("laravel.pint.runOnCurrentFile"),
@@ -38,12 +41,14 @@ const runPintCommand = (
 
         const command = `${getCommand("vendor/bin/pint")} ${args}`.trim();
 
-        cp.exec(
+        runningProcess = cp.exec(
             command,
             {
                 cwd: projectPath(),
             },
             (err, stdout, stderr) => {
+                runningProcess = undefined;
+
                 if (err === null) {
                     if (showSuccessMessage) {
                         statusBarSuccess("Pint completed successfully!");
@@ -129,7 +134,20 @@ export const runPintOnSave = (document: vscode.TextDocument) => {
         return;
     }
 
-    runPintOnFile(document.uri.fsPath, false);
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+    }
+
+    debounceTimer = setTimeout(() => {
+        debounceTimer = undefined;
+
+        if (runningProcess) {
+            runningProcess.kill();
+            runningProcess = undefined;
+        }
+
+        runPintOnFile(document.uri.fsPath, false);
+    }, 300);
 };
 
 export class PintEditProvider implements vscode.DocumentFormattingEditProvider {


### PR DESCRIPTION
When `pint.runOnSave` is enabled, each save spawns a new child process with no protection against concurrent execution. If the user saves rapidly, multiple Pint processes can run simultaneously on the same file, causing conflicts between the saved version and the Pint-formatted version.

This adds two internal safeguards:

**Debounce:** Save events are debounced with a `300ms` delay, collapsing rapid saves into a single Pint run.
**Cancel in-flight processes:** If a Pint process is still running when a new debounced run starts, the existing process is killed before spawning a new one.

No user-facing configuration changes.

https://github.com/laravel/vs-code-extension/issues/612