### PR TITLE
Link Livewire page routes to components

### DIFF
--- a/php-templates/routes.php
+++ b/php-templates/routes.php
@@ -66,7 +66,17 @@ $routes = new class {
             'parameters' => $route->parameterNames(),
             'filename' => $reflection ? LaravelVsCode::relativePath($reflection->getFileName()) : null,
             'line' => $reflection ? $reflection->getStartLine() : null,
+            'livewire' => $this->getLivewireView($route),
         ];
+    }
+
+    protected function getLivewireView(\Illuminate\Routing\Route $route): ?string
+    {
+        if ($route->getActionName() !== 'Livewire\Features\SupportRouting\LivewirePageController') {
+            return null;
+        }
+
+        return $route->defaults['_livewire_component'] ?? null;
     }
 
     protected function getRouteReflection(\Illuminate\Routing\Route $route)

--- a/src/features/livewireComponent.ts
+++ b/src/features/livewireComponent.ts
@@ -3,7 +3,7 @@ import { config } from "@src/support/config";
 import { projectPath } from "@src/support/project";
 import * as vscode from "vscode";
 import { HoverProvider, LinkProvider } from "..";
-import { appendProps } from "@src/support/markdown";
+import { livewireHover } from "@src/support/markdown";
 
 export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
     const links: vscode.DocumentLink[] = [];
@@ -66,21 +66,11 @@ export const hoverProvider: HoverProvider = (
         return v.key === `livewire.${match}` || (v.livewire && v.key === match);
     });
 
-    if (!view || !view.livewire) {
+    if (!view?.livewire) {
         return null;
     }
 
-    const markdown = new vscode.MarkdownString();
-
-    const files = view.livewire.files.map((path) => {
-        return `[${path}](${vscode.Uri.file(projectPath(path))})`;
-    });
-
-    markdown.appendMarkdown(files.join("\n\n"));
-
-    appendProps(markdown, view.livewire.props);
-
-    return new vscode.Hover(markdown);
+    return livewireHover(view.livewire);
 };
 
 export const completionProvider: vscode.CompletionItemProvider = {

--- a/src/features/route.ts
+++ b/src/features/route.ts
@@ -7,6 +7,7 @@ import { findHoverMatchesInDoc } from "@src/support/doc";
 import { detectedRange, detectInDoc } from "@src/support/parser";
 import { wordMatchRegex } from "@src/support/patterns";
 import { projectPath, relativePath } from "@src/support/project";
+import { livewireHover } from "@src/support/markdown";
 import { contract, facade } from "@src/support/util";
 import { AutocompleteParsingResult } from "@src/types";
 import * as vscode from "vscode";
@@ -96,7 +97,24 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
                 (route) => route.name === param.value,
             );
 
-            if (!route || !route.filename) {
+            if (!route) {
+                return null;
+            }
+
+            if (route.livewire) {
+                const view = getViews().items.find(
+                    (v) => v.key === route.livewire,
+                );
+
+                if (view) {
+                    return new vscode.DocumentLink(
+                        detectedRange(param),
+                        vscode.Uri.file(projectPath(view.path)),
+                    );
+                }
+            }
+
+            if (!route.filename) {
                 return null;
             }
 
@@ -121,7 +139,21 @@ export const hoverProvider: HoverProvider = (
 
         const routeItem = getRoutes().items.find((r) => r.name === match);
 
-        if (!routeItem || !routeItem.filename || !routeItem.line) {
+        if (!routeItem) {
+            return null;
+        }
+
+        if (routeItem.livewire) {
+            const view = getViews().items.find(
+                (v) => v.key === routeItem.livewire,
+            );
+
+            if (view?.livewire) {
+                return livewireHover(view.livewire);
+            }
+        }
+
+        if (!routeItem.filename || !routeItem.line) {
             return null;
         }
 

--- a/src/repositories/routes.ts
+++ b/src/repositories/routes.ts
@@ -10,6 +10,7 @@ interface RouteItem {
     parameters: string[];
     filename: string | null;
     line: number | null;
+    livewire: string | null;
 }
 
 const routesPattern = "{[Rr]oute}{,s}{.php,/*.php,/**/*.php}";

--- a/src/support/markdown.ts
+++ b/src/support/markdown.ts
@@ -1,4 +1,22 @@
+import { ViewItem } from "@src/repositories/views";
+import { projectPath } from "@src/support/project";
 import * as vscode from "vscode";
+
+export const livewireHover = (
+    livewire: NonNullable<ViewItem["livewire"]>,
+): vscode.Hover => {
+    const markdown = new vscode.MarkdownString();
+
+    const files = livewire.files.map((path) => {
+        return `[${path}](${vscode.Uri.file(projectPath(path))})`;
+    });
+
+    markdown.appendMarkdown(files.join("\n\n"));
+
+    appendProps(markdown, livewire.props);
+
+    return new vscode.Hover(markdown);
+};
 
 export const appendProps = (
     markdown: vscode.MarkdownString,

--- a/src/templates/routes.ts
+++ b/src/templates/routes.ts
@@ -66,7 +66,17 @@ $routes = new class {
             'parameters' => $route->parameterNames(),
             'filename' => $reflection ? LaravelVsCode::relativePath($reflection->getFileName()) : null,
             'line' => $reflection ? $reflection->getStartLine() : null,
+            'livewire' => $this->getLivewireView($route),
         ];
+    }
+
+    protected function getLivewireView(\\Illuminate\\Routing\\Route $route): ?string
+    {
+        if ($route->getActionName() !== 'Livewire\\Features\\SupportRouting\\LivewirePageController') {
+            return null;
+        }
+
+        return $route->defaults['_livewire_component'] ?? null;
     }
 
     protected function getRouteReflection(\\Illuminate\\Routing\\Route $route)


### PR DESCRIPTION
Routes registered with `Route::livewire()` now link directly to the Livewire component instead of Livewire's internal `LivewirePageController`.

Clicking a route name like `route('images.index')` navigates to the component file, and hovering displays the full component hover card with all associated files and props.

<img width="710" height="169" alt="Screenshot 2026-03-19 at 16 36 48" src="https://github.com/user-attachments/assets/3ca53f68-335b-428b-be5c-0fac482e355f" />

<img width="475" height="265" alt="Screenshot 2026-03-19 at 16 36 35" src="https://github.com/user-attachments/assets/3f014bec-675f-445a-9278-be92a7e69ef5" />
