### PR TITLE
Increase parser timeout and improve error messages on Windows

### DIFF
--- a/src/support/parser.ts
+++ b/src/support/parser.ts
@@ -182,7 +182,9 @@ const runCommand = (command: string, args: string[]): Promise<string> => {
                 }
 
                 if (err.killed) {
-                    return reject(`Parser timed out after ${PARSER_TIMEOUT_MS / 1000} seconds. `);
+                    return reject(
+                        `Parser timed out after ${PARSER_TIMEOUT_MS / 1000} seconds. `,
+                    );
                 }
 
                 const details = [


### PR DESCRIPTION
Increase the parser binary execution timeout from 5 seconds to 30 seconds, fixing failures on Windows where antivirus scanning and slower I/O cause the binary to exceed the previous limit.

Detect timeout errors specifically and surface a descriptive message.

Include `err.message`, `stderr`, `stdout`, and exit code in non-timeout error messages for better diagnostics.

I hope this helps with #582 #617 