### PR TITLE
Avoid overlapping test explorer updates

### DIFF
--- a/src/test-runner/explorer.ts
+++ b/src/test-runner/explorer.ts
@@ -17,32 +17,12 @@ export interface TestSuite {
     }[];
 }
 
-let runningUpdate: Promise<void> | undefined;
-let refreshQueued = false;
-
 export const updateExplorer = async (controller: vscode.TestController) => {
-    if (runningUpdate) {
-        refreshQueued = true;
-        return runningUpdate;
-    }
+    const suites = await getTestSuites();
 
-    const update = (async () => {
-        do {
-            refreshQueued = false;
-
-            const suites = await getTestSuites();
-
-            controller.items.replace(
-                suites.map((suite) => buildSuiteItem(controller, suite)),
-            );
-        } while (refreshQueued);
-    })().finally(() => {
-        runningUpdate = undefined;
-    });
-
-    runningUpdate = update;
-
-    return update;
+    controller.items.replace(
+        suites.map((suite) => buildSuiteItem(controller, suite)),
+    );
 };
 
 const getTestSuites = () => {


### PR DESCRIPTION
Currently, the test runner can start multiple explorer refreshes at the same time when test files change quickly. This is especially devastating when switching branches with a large number of test file changes.

This PR makes explorer updates run one at a time and queues a follow-up refresh if additional file events arrive while an update is already in progress. That follows the same general approach already used elsewhere in the extension for rapid repeated events, such as the Pint-on-save flow.

It also aligns the test runner file watcher with the repository file watcher by using the `loadAndWatch` helper.
