### PR TITLE
Inertia V3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Route::inertia('/dashboard', 'Pages/Dashboard');
     - Create view
 - Hoverable
 
-**Note:** If the extension is unable to find your Inertia views, you may need to update your `inertia.testing.page_paths` and/or `inertia.testing.page_extensions` config values.
+**Note:** If the extension is unable to find your Inertia views, ensure your `inertia.pages.paths` and/or `inertia.pages.extensions` config values are correct. Older projects may still use `inertia.page_*` or `inertia.testing.page_*`.
 
 ### Route
 

--- a/php-templates/inertia.php
+++ b/php-templates/inertia.php
@@ -1,8 +1,18 @@
 <?php
 
+$pageExtensions = config(
+    'inertia.pages.extensions',
+    config('inertia.page_extensions', config('inertia.testing.page_extensions', [])),
+);
+
+$pagePaths = config(
+    'inertia.pages.paths',
+    config('inertia.page_paths', config('inertia.testing.page_paths', [])),
+);
+
 echo json_encode([
-    'page_extensions' => config('inertia.page_extensions', config('inertia.testing.page_extensions', [])),
-    'page_paths' => collect(config('inertia.page_paths', config('inertia.testing.page_paths', [])))->flatMap(function($path) {
+    'page_extensions' => $pageExtensions,
+    'page_paths' => collect($pagePaths)->flatMap(function($path) {
         $relativePath = LaravelVsCode::relativePath($path);
 
         return [$relativePath, mb_strtolower($relativePath)];

--- a/src/templates/inertia.ts
+++ b/src/templates/inertia.ts
@@ -1,8 +1,18 @@
 // This file was generated from php-templates/inertia.php, do not edit directly
 export default `
+$pageExtensions = config(
+    'inertia.pages.extensions',
+    config('inertia.page_extensions', config('inertia.testing.page_extensions', [])),
+);
+
+$pagePaths = config(
+    'inertia.pages.paths',
+    config('inertia.page_paths', config('inertia.testing.page_paths', [])),
+);
+
 echo json_encode([
-    'page_extensions' => config('inertia.page_extensions', config('inertia.testing.page_extensions', [])),
-    'page_paths' => collect(config('inertia.page_paths', config('inertia.testing.page_paths', [])))->flatMap(function($path) {
+    'page_extensions' => $pageExtensions,
+    'page_paths' => collect($pagePaths)->flatMap(function($path) {
         $relativePath = LaravelVsCode::relativePath($path);
 
         return [$relativePath, mb_strtolower($relativePath)];


### PR DESCRIPTION
## Summary
- Update Inertia template config lookup to prefer the new `inertia.pages.paths` and `inertia.pages.extensions` keys.
- Preserve compatibility with older `inertia.page_*` and `inertia.testing.page_*` config values as fallback.
- Refresh the README note to point users at the new config keys.