### PR TITLE
Build models template for snake_case relation fix

### DIFF
--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -168,6 +168,12 @@ $models = new class($factory) {
             ->values()
             ->toArray();
 
+        $data['relations'] = collect($data['relations'])
+            ->map(fn($relation) => array_merge($relation, [
+                'snake_case' => \\Illuminate\\Support\\Str::snake($relation['name']),
+            ]))
+            ->toArray();
+
         $data['uri'] = $reflection->getFileName();
 
         return [


### PR DESCRIPTION
## Summary

- Builds the models template that was missed in #611
- Adds `snake_case` key to relation data using `Str::snake()` in the compiled template

This ensures the `snake_case` fix for relation count attributes actually takes effect at runtime.
