### PR TITLE
Add support for functions defined in Pest helper files

### DIFF
--- a/php-templates/pest.php
+++ b/php-templates/pest.php
@@ -25,6 +25,18 @@ $pest = new class {
         if (file_exists($pestFile = base_path('tests/Pest.php'))) {
             require_once $pestFile;
         }
+
+        if (is_dir($helpersDir = base_path('tests/Helpers'))) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($helpersDir)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    require_once $file->getRealPath();
+                }
+            }
+        }
     }
 
     public function config(): ?array

--- a/php-templates/tests.php
+++ b/php-templates/tests.php
@@ -69,6 +69,18 @@ $tests = new class {
         if (file_exists($pestFile = base_path('tests/Pest.php'))) {
             require_once $pestFile;
         }
+
+        if (is_dir($helpersDir = base_path('tests/Helpers'))) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($helpersDir)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    require_once $file->getRealPath();
+                }
+            }
+        }
     }
 
     /**

--- a/src/templates/pest.ts
+++ b/src/templates/pest.ts
@@ -25,6 +25,18 @@ $pest = new class {
         if (file_exists($pestFile = base_path('tests/Pest.php'))) {
             require_once $pestFile;
         }
+
+        if (is_dir($helpersDir = base_path('tests/Helpers'))) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($helpersDir)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    require_once $file->getRealPath();
+                }
+            }
+        }
     }
 
     public function config(): ?array

--- a/src/templates/tests.ts
+++ b/src/templates/tests.ts
@@ -69,6 +69,18 @@ $tests = new class {
         if (file_exists($pestFile = base_path('tests/Pest.php'))) {
             require_once $pestFile;
         }
+
+        if (is_dir($helpersDir = base_path('tests/Helpers'))) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($helpersDir)
+            );
+
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    require_once $file->getRealPath();
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Adds support for discovering functions defined in Pest helper files (https://pestphp.com/docs/custom-helpers)

Closes #638

I have run the local debugging / testing steps outlined in [CONTRIBUTING.md](https://github.com/laravel/vs-code-extension/blob/main/CONTRIBUTING.md) and have confirmed that this fixes the issue compared to running `main`