### PR TITLE
Rename support for variables and classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1089,6 +1089,11 @@
                     "default": true,
                     "description": "Enable the test runner integration."
                 },
+                "Laravel.rename.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable Laravel-specific rename functionality. Disable this if another extension already provides rename support."
+                },
                 "Laravel.artisanMake.explorer": {
                     "type": "boolean",
                     "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,7 @@ import {
 import { configureDockerEnvironment } from "./commands/configureDockerEnvironment";
 import { registerPestHelper } from "./features/pest";
 import { registerTestRunner } from "./test-runner";
+import { PhpRenameProvider } from "./renameProvider";
 
 let client: LanguageClient;
 
@@ -275,6 +276,7 @@ export async function activate(context: vscode.ExtensionContext) {
             commandName("laravel.docker.configure"),
             configureDockerEnvironment,
         ),
+        vscode.languages.registerRenameProvider(PHP_LANGUAGE, new PhpRenameProvider()),
     );
 
     collectDebugInfo();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -276,7 +276,10 @@ export async function activate(context: vscode.ExtensionContext) {
             commandName("laravel.docker.configure"),
             configureDockerEnvironment,
         ),
-        vscode.languages.registerRenameProvider(PHP_LANGUAGE, new PhpRenameProvider()),
+        vscode.languages.registerRenameProvider(
+            PHP_LANGUAGE,
+            new PhpRenameProvider(),
+        ),
     );
 
     collectDebugInfo();

--- a/src/renameApi.ts
+++ b/src/renameApi.ts
@@ -1,0 +1,137 @@
+import {
+    DocumentSymbol,
+    Location,
+    LocationLink,
+    Position,
+    SymbolInformation,
+    Uri,
+    commands,
+} from 'vscode';
+import { getTargetUri } from './renameUtils';
+
+const isDocumentSymbol = (
+    symbol: DocumentSymbol | SymbolInformation
+): symbol is DocumentSymbol => {
+    return (symbol as DocumentSymbol).children !== undefined;
+};
+
+const toDocumentSymbol = (
+    symbol: DocumentSymbol | SymbolInformation
+): DocumentSymbol => {
+    if (isDocumentSymbol(symbol)) {
+        return symbol;
+    }
+
+    const range = symbol.location.range;
+    return new DocumentSymbol(
+        symbol.name,
+        symbol.containerName ?? '',
+        symbol.kind,
+        range,
+        range
+    );
+};
+
+export const getDocumentSymbols = async (uri: Uri): Promise<DocumentSymbol[]> => {
+    if (!uri) {
+        return [];
+    }
+
+    const result = await commands.executeCommand<(DocumentSymbol | SymbolInformation)[]>(
+        'vscode.executeDocumentSymbolProvider',
+        uri
+    );
+
+    return (result ?? []).map(toDocumentSymbol);
+};
+
+export const getDefinition = async (
+    uri: Uri,
+    position: Position
+): Promise<Location | LocationLink | null> => {
+
+    const definitions = await commands.executeCommand<(Location | LocationLink)[]>(
+        'vscode.executeDefinitionProvider',
+        uri,
+        position
+    );
+
+    if (!definitions || definitions.length === 0) {
+        return null;
+    }
+
+    return definitions[0];
+};
+
+export const getReferences = async (
+    uri: Uri,
+    position: Position
+): Promise<Location[]> => {
+
+    const refs = await commands.executeCommand<Location[]>(
+        'vscode.executeReferenceProvider',
+        uri,
+        position
+    );
+
+    return refs ?? [];
+};
+
+export const getSymbol = async (
+    uri: Uri,
+    position: Position
+): Promise<[DocumentSymbol, Location | LocationLink] | null> => {
+
+    const definition = await getDefinition(uri, position);
+
+    if (!definition) {
+        return null;
+    }
+
+    const targetUri = getTargetUri(definition);
+
+    if (!targetUri) {
+        return null;
+    }
+
+    const symbols = flattenDocumentSymbols(
+        await getDocumentSymbols(targetUri)
+    );
+
+    if ('targetRange' in definition) {
+        for (const symbol of symbols) {
+            if (definition.targetRange.contains(symbol.selectionRange)) {
+                return [symbol, definition];
+            }
+        }
+    }
+
+    const references = await getReferences(uri, position);
+
+    for (const reference of references) {
+        for (const symbol of symbols) {
+            if (symbol.selectionRange.contains(reference.range)) {
+                return [symbol, definition];
+            }
+        }
+    }
+
+    return null;
+};
+
+const flattenDocumentSymbols = (symbols: DocumentSymbol[]): DocumentSymbol[] => {
+    const result: DocumentSymbol[] = [];
+
+    const visit = (symbol: DocumentSymbol) => {
+        result.push(symbol);
+        for (const child of symbol.children ?? []) {
+            visit(child);
+        }
+    };
+
+    for (const symbol of symbols ?? []) {
+        visit(symbol);
+    }
+
+    return result;
+};

--- a/src/renameApi.ts
+++ b/src/renameApi.ts
@@ -6,17 +6,17 @@ import {
     SymbolInformation,
     Uri,
     commands,
-} from 'vscode';
-import { getTargetUri } from './renameUtils';
+} from "vscode";
+import { getTargetUri } from "./renameUtils";
 
 const isDocumentSymbol = (
-    symbol: DocumentSymbol | SymbolInformation
+    symbol: DocumentSymbol | SymbolInformation,
 ): symbol is DocumentSymbol => {
     return (symbol as DocumentSymbol).children !== undefined;
 };
 
 const toDocumentSymbol = (
-    symbol: DocumentSymbol | SymbolInformation
+    symbol: DocumentSymbol | SymbolInformation,
 ): DocumentSymbol => {
     if (isDocumentSymbol(symbol)) {
         return symbol;
@@ -25,36 +25,34 @@ const toDocumentSymbol = (
     const range = symbol.location.range;
     return new DocumentSymbol(
         symbol.name,
-        symbol.containerName ?? '',
+        symbol.containerName ?? "",
         symbol.kind,
         range,
-        range
+        range,
     );
 };
 
-export const getDocumentSymbols = async (uri: Uri): Promise<DocumentSymbol[]> => {
+export const getDocumentSymbols = async (
+    uri: Uri,
+): Promise<DocumentSymbol[]> => {
     if (!uri) {
         return [];
     }
 
-    const result = await commands.executeCommand<(DocumentSymbol | SymbolInformation)[]>(
-        'vscode.executeDocumentSymbolProvider',
-        uri
-    );
+    const result = await commands.executeCommand<
+        (DocumentSymbol | SymbolInformation)[]
+    >("vscode.executeDocumentSymbolProvider", uri);
 
     return (result ?? []).map(toDocumentSymbol);
 };
 
 export const getDefinition = async (
     uri: Uri,
-    position: Position
+    position: Position,
 ): Promise<Location | LocationLink | null> => {
-
-    const definitions = await commands.executeCommand<(Location | LocationLink)[]>(
-        'vscode.executeDefinitionProvider',
-        uri,
-        position
-    );
+    const definitions = await commands.executeCommand<
+        (Location | LocationLink)[]
+    >("vscode.executeDefinitionProvider", uri, position);
 
     if (!definitions || definitions.length === 0) {
         return null;
@@ -65,13 +63,12 @@ export const getDefinition = async (
 
 export const getReferences = async (
     uri: Uri,
-    position: Position
+    position: Position,
 ): Promise<Location[]> => {
-
     const refs = await commands.executeCommand<Location[]>(
-        'vscode.executeReferenceProvider',
+        "vscode.executeReferenceProvider",
         uri,
-        position
+        position,
     );
 
     return refs ?? [];
@@ -79,9 +76,8 @@ export const getReferences = async (
 
 export const getSymbol = async (
     uri: Uri,
-    position: Position
+    position: Position,
 ): Promise<[DocumentSymbol, Location | LocationLink] | null> => {
-
     const definition = await getDefinition(uri, position);
 
     if (!definition) {
@@ -94,11 +90,9 @@ export const getSymbol = async (
         return null;
     }
 
-    const symbols = flattenDocumentSymbols(
-        await getDocumentSymbols(targetUri)
-    );
+    const symbols = flattenDocumentSymbols(await getDocumentSymbols(targetUri));
 
-    if ('targetRange' in definition) {
+    if ("targetRange" in definition) {
         for (const symbol of symbols) {
             if (definition.targetRange.contains(symbol.selectionRange)) {
                 return [symbol, definition];
@@ -119,7 +113,9 @@ export const getSymbol = async (
     return null;
 };
 
-const flattenDocumentSymbols = (symbols: DocumentSymbol[]): DocumentSymbol[] => {
+const flattenDocumentSymbols = (
+    symbols: DocumentSymbol[],
+): DocumentSymbol[] => {
     const result: DocumentSymbol[] = [];
 
     const visit = (symbol: DocumentSymbol) => {

--- a/src/renameBase.ts
+++ b/src/renameBase.ts
@@ -1,25 +1,20 @@
-import * as path from 'path';
-import {
-    Location,
-    LocationLink,
-    Uri,
-    WorkspaceEdit,
-} from 'vscode';
-import { getTargetUri } from './renameUtils';
+import * as path from "path";
+import { Location, LocationLink, Uri, WorkspaceEdit } from "vscode";
+import { getTargetUri } from "./renameUtils";
 
 export abstract class BaseRenameProvider {
     protected renameProperty(
         actualName: string,
         location: Location,
         newName: string,
-        edit: WorkspaceEdit
+        edit: WorkspaceEdit,
     ): void {
-        const normalized = newName.replace(/^\$/, '');
+        const normalized = newName.replace(/^\$/, "");
 
         edit.replace(
             location.uri,
             location.range,
-            actualName.startsWith('$') ? `$${normalized}` : normalized
+            actualName.startsWith("$") ? `$${normalized}` : normalized,
         );
     }
 
@@ -27,21 +22,21 @@ export abstract class BaseRenameProvider {
         location: Location,
         oldName: string,
         newName: string,
-        edit: WorkspaceEdit
+        edit: WorkspaceEdit,
     ): void {
         edit.replace(
             location.uri,
             location.range.with(
-                location.range.end.translate(0, -oldName.length)
+                location.range.end.translate(0, -oldName.length),
             ),
-            newName
+            newName,
         );
     }
 
     protected renameFile(
         edit: WorkspaceEdit,
         definition: Location | LocationLink,
-        newName: string
+        newName: string,
     ): void {
         const uri = getTargetUri(definition);
 
@@ -52,13 +47,13 @@ export abstract class BaseRenameProvider {
         const newPath = path.format({
             dir: path.dirname(uri.path),
             name: newName,
-            ext: '.php',
+            ext: ".php",
         });
 
         edit.renameFile(uri, uri.with({ path: newPath }));
     }
 
     protected isFromVendor(uri: Uri): boolean {
-        return uri.path.includes('vendor');
+        return uri.path.includes("vendor");
     }
 }

--- a/src/renameBase.ts
+++ b/src/renameBase.ts
@@ -1,0 +1,64 @@
+import * as path from 'path';
+import {
+    Location,
+    LocationLink,
+    Uri,
+    WorkspaceEdit,
+} from 'vscode';
+import { getTargetUri } from './renameUtils';
+
+export abstract class BaseRenameProvider {
+    protected renameProperty(
+        actualName: string,
+        location: Location,
+        newName: string,
+        edit: WorkspaceEdit
+    ): void {
+        const normalized = newName.replace(/^\$/, '');
+
+        edit.replace(
+            location.uri,
+            location.range,
+            actualName.startsWith('$') ? `$${normalized}` : normalized
+        );
+    }
+
+    protected renameClassLike(
+        location: Location,
+        oldName: string,
+        newName: string,
+        edit: WorkspaceEdit
+    ): void {
+        edit.replace(
+            location.uri,
+            location.range.with(
+                location.range.end.translate(0, -oldName.length)
+            ),
+            newName
+        );
+    }
+
+    protected renameFile(
+        edit: WorkspaceEdit,
+        definition: Location | LocationLink,
+        newName: string
+    ): void {
+        const uri = getTargetUri(definition);
+
+        if (!uri) {
+            return;
+        }
+
+        const newPath = path.format({
+            dir: path.dirname(uri.path),
+            name: newName,
+            ext: '.php',
+        });
+
+        edit.renameFile(uri, uri.with({ path: newPath }));
+    }
+
+    protected isFromVendor(uri: Uri): boolean {
+        return uri.path.includes('vendor');
+    }
+}

--- a/src/renameProvider.ts
+++ b/src/renameProvider.ts
@@ -1,0 +1,92 @@
+import {
+    Position,
+    RenameProvider,
+    TextDocument,
+    WorkspaceEdit,
+    SymbolKind,
+    LocationLink,
+    Location,
+} from 'vscode';
+import { getReferences, getSymbol } from './renameApi';
+import { getTargetUri } from './renameUtils';
+import { BaseRenameProvider } from './renameBase';
+
+export class PhpRenameProvider extends BaseRenameProvider implements RenameProvider {
+
+    public async provideRenameEdits(
+        document: TextDocument,
+        position: Position,
+        newName: string
+    ): Promise<WorkspaceEdit | null> {
+
+        const wordRange = document.getWordRangeAtPosition(position);
+        if (!wordRange) {
+            return null;
+        }
+
+        const oldName = document.getText(wordRange);
+
+        const references = await getReferences(document.uri, position);
+
+        if (!references || references.length === 0) {
+            throw new Error('You can not rename this symbol');
+        }
+
+        const symbolResult = await getSymbol(document.uri, position);
+
+        if (symbolResult) {
+            const [, def] = symbolResult;
+            const targetUri = getTargetUri(def);
+
+            if (targetUri && this.isFromVendor(targetUri)) {
+                throw new Error('You can not rename symbols from vendor');
+            }
+        }
+
+        const edit = new WorkspaceEdit();
+
+        for (const location of references) {
+            if (symbolResult) {
+                const [symbol] = symbolResult;
+
+                switch (symbol.kind) {
+                    case SymbolKind.Property:
+                        this.renameProperty(
+                            document.getText(location.range),
+                            location,
+                            newName,
+                            edit
+                        );
+                        break;
+
+                    case SymbolKind.Class:
+                    case SymbolKind.Interface:
+                    case SymbolKind.Module:
+                        this.renameClassLike(location, oldName, newName, edit);
+                        break;
+
+                    default:
+                        edit.replace(location.uri, location.range, newName);
+                        break;
+                }
+
+            } else {
+                edit.replace(location.uri, location.range, newName);
+            }
+        }
+
+        if (symbolResult) {
+            const [symbol, def] = symbolResult;
+
+            if (
+                symbol.kind === SymbolKind.Class ||
+                symbol.kind === SymbolKind.Interface ||
+                symbol.kind === SymbolKind.Module
+            ) {
+                this.renameFile(edit, def, newName);
+            }
+        }
+
+        return edit;
+    }
+}

--- a/src/renameProvider.ts
+++ b/src/renameProvider.ts
@@ -4,12 +4,13 @@ import {
     TextDocument,
     WorkspaceEdit,
     SymbolKind,
-    LocationLink,
-    Location,
+    window,
+    commands,
 } from "vscode";
 import { getReferences, getSymbol } from "./renameApi";
 import { getTargetUri } from "./renameUtils";
 import { BaseRenameProvider } from "./renameBase";
+import { config } from "./support/config";
 
 export class PhpRenameProvider
     extends BaseRenameProvider
@@ -20,6 +21,24 @@ export class PhpRenameProvider
         position: Position,
         newName: string,
     ): Promise<WorkspaceEdit | null> {
+        if (!config<boolean>("rename.enable", true)) {
+            window
+                .showWarningMessage(
+                    "Laravel rename is disabled in settings.",
+                    "Open Settings",
+                )
+                .then((action) => {
+                    if (action === "Open Settings") {
+                        commands.executeCommand(
+                            "workbench.action.openSettings",
+                            "laravel.rename.enable",
+                        );
+                    }
+                });
+
+            return null;
+        }
+
         const wordRange = document.getWordRangeAtPosition(position);
         if (!wordRange) {
             return null;

--- a/src/renameProvider.ts
+++ b/src/renameProvider.ts
@@ -6,19 +6,20 @@ import {
     SymbolKind,
     LocationLink,
     Location,
-} from 'vscode';
-import { getReferences, getSymbol } from './renameApi';
-import { getTargetUri } from './renameUtils';
-import { BaseRenameProvider } from './renameBase';
+} from "vscode";
+import { getReferences, getSymbol } from "./renameApi";
+import { getTargetUri } from "./renameUtils";
+import { BaseRenameProvider } from "./renameBase";
 
-export class PhpRenameProvider extends BaseRenameProvider implements RenameProvider {
-
+export class PhpRenameProvider
+    extends BaseRenameProvider
+    implements RenameProvider
+{
     public async provideRenameEdits(
         document: TextDocument,
         position: Position,
-        newName: string
+        newName: string,
     ): Promise<WorkspaceEdit | null> {
-
         const wordRange = document.getWordRangeAtPosition(position);
         if (!wordRange) {
             return null;
@@ -29,7 +30,7 @@ export class PhpRenameProvider extends BaseRenameProvider implements RenameProvi
         const references = await getReferences(document.uri, position);
 
         if (!references || references.length === 0) {
-            throw new Error('You can not rename this symbol');
+            throw new Error("You can not rename this symbol");
         }
 
         const symbolResult = await getSymbol(document.uri, position);
@@ -39,7 +40,7 @@ export class PhpRenameProvider extends BaseRenameProvider implements RenameProvi
             const targetUri = getTargetUri(def);
 
             if (targetUri && this.isFromVendor(targetUri)) {
-                throw new Error('You can not rename symbols from vendor');
+                throw new Error("You can not rename symbols from vendor");
             }
         }
 
@@ -55,7 +56,7 @@ export class PhpRenameProvider extends BaseRenameProvider implements RenameProvi
                             document.getText(location.range),
                             location,
                             newName,
-                            edit
+                            edit,
                         );
                         break;
 
@@ -69,7 +70,6 @@ export class PhpRenameProvider extends BaseRenameProvider implements RenameProvi
                         edit.replace(location.uri, location.range, newName);
                         break;
                 }
-
             } else {
                 edit.replace(location.uri, location.range, newName);
             }

--- a/src/renameUtils.ts
+++ b/src/renameUtils.ts
@@ -1,7 +1,7 @@
 import { Location, LocationLink, Uri } from "vscode";
 
 export const getTargetUri = (def: Location | LocationLink): Uri | undefined => {
-    if ('targetUri' in def) {
+    if ("targetUri" in def) {
         return def.targetUri;
     }
     return def.uri;

--- a/src/renameUtils.ts
+++ b/src/renameUtils.ts
@@ -1,0 +1,8 @@
+import { Location, LocationLink, Uri } from "vscode";
+
+export const getTargetUri = (def: Location | LocationLink): Uri | undefined => {
+    if ('targetUri' in def) {
+        return def.targetUri;
+    }
+    return def.uri;
+};

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -16,7 +16,8 @@ type ConfigKey =
     | "pest.helperFilePath"
     | "env.viteQuickFix"
     | "pint.runOnSave"
-    | "testRunner.enabled";
+    | "testRunner.enabled"
+    | "rename.enable";
 
 export const config = <T>(key: ConfigKey, fallback: T): T =>
     vscode.workspace.getConfiguration("Laravel").get<T>(key, fallback);


### PR DESCRIPTION
### Summary

Adds a PHP rename provider to improve renaming of variables, properties, and class-like symbols.

### Details

* Uses VS Code definition, reference, and document symbol providers to resolve symbols
* Renames all references consistently
* Preserves `$` prefix when renaming properties
* Renames class/interface/module usages and their corresponding file
* Prevents renaming inside `vendor` directory

### Notes

This is a small enhancement to make rename behavior more reliable without introducing breaking changes.