### PR TITLE
[631] - Support @use trait annotations in models.

### DIFF
--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -138,6 +138,64 @@ $models = new class($factory) {
         return \Illuminate\Support\Str::start($parent, '\\');
     }
 
+    protected function collectTraitUseAnnotations(\ReflectionClass $reflection)
+    {
+        $fileName = $reflection->getFileName();
+
+        if (!$fileName || !file_exists($fileName)) {
+            return [];
+        }
+
+        $source = file_get_contents($fileName);
+
+        $imports = [];
+        $classPos = preg_match('/^\s*(?:abstract\s+|final\s+|readonly\s+)*class\s+/m', $source, $classMatch, PREG_OFFSET_CAPTURE)
+            ? $classMatch[0][1]
+            : strlen($source);
+
+        $headerSource = substr($source, 0, $classPos);
+
+        if (preg_match_all('/^\s*use\s+([\w\\\\]+?)(?:\s+as\s+(\w+))?\s*;/m', $headerSource, $importMatches, PREG_SET_ORDER)) {
+            foreach ($importMatches as $im) {
+                $fqcn = $im[1];
+                $alias = $im[2] ?? substr(strrchr($fqcn, '\\'), 1) ?: $fqcn;
+                $imports[$alias] = $fqcn;
+            }
+        }
+
+        $traitUses = [];
+        $bodySource = substr($source, $classPos);
+
+        if (preg_match_all('/\/\*\*(?:[^*]|\*(?!\/))*?@use\s+([^\s*]+)(?:[^*]|\*(?!\/))*?\*\/\s*\n\s*use\s+([^;]+);/m', $bodySource, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $annotation = trim($match[1]);
+                $traits = trim($match[2]);
+
+                $resolvedAnnotation = preg_replace_callback('/^([\w]+)/', function ($m) use ($imports) {
+                    return isset($imports[$m[1]])
+                        ? '\\' . $imports[$m[1]]
+                        : $m[1];
+                }, $annotation);
+
+                $resolvedTraits = collect(explode(',', $traits))
+                    ->map(function ($trait) use ($imports) {
+                        $trait = trim($trait);
+                        return isset($imports[$trait])
+                            ? '\\' . $imports[$trait]
+                            : $trait;
+                    })
+                    ->implode(', ');
+
+                $traitUses[] = [
+                    'annotation' => $resolvedAnnotation,
+                    'traits' => $resolvedTraits,
+                ];
+            }
+        }
+
+        return $traitUses;
+    }
+
     protected function getInfo($className)
     {
         if (($data = $this->fromArtisan($className)) === null) {
@@ -175,6 +233,8 @@ $models = new class($factory) {
             ->toArray();
 
         $data['path'] = LaravelVsCode::relativePath($reflection->getFileName() ?: '');
+
+        $data['traitUses'] = $this->collectTraitUseAnnotations($reflection);
 
         return [
             $className => $data,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -84,6 +84,12 @@ declare namespace Eloquent {
         scopes: Scope[];
         extends: string | null;
         path: string;
+        traitUses: TraitUse[];
+    }
+
+    interface TraitUse {
+        annotation: string;
+        traits: string;
     }
 
     interface Attribute {

--- a/src/support/docblocks.ts
+++ b/src/support/docblocks.ts
@@ -9,6 +9,7 @@ interface ClassBlock {
     className: string;
     blocks: string[];
     extends: string | null;
+    traitUses: Eloquent.TraitUse[];
 }
 
 const modelBuilderType = (className: string) =>
@@ -31,6 +32,7 @@ export const writeEloquentDocBlocks = (
             className: cls || "",
             blocks: getBlocks(model, cls || "", builderMethods),
             extends: model.extends || null,
+            traitUses: model.traitUses || [],
         };
     });
 
@@ -200,6 +202,14 @@ const getScopeBlock = (
 };
 
 const classToDocBlock = (block: ClassBlock, namespace: string) => {
+    const traitLines =
+        block.traitUses.length > 0
+            ? block.traitUses.flatMap((tu) => [
+                  `/** @use ${tu.annotation} */`,
+                  `use ${tu.traits};`,
+              ])
+            : ["//"];
+
     return [
         `/**`,
         ` * ${namespace}\\${block.className}`,
@@ -211,7 +221,7 @@ const classToDocBlock = (block: ClassBlock, namespace: string) => {
             block.extends ?? "\\Illuminate\\Database\\Eloquent\\Model"
         }`,
         `{`,
-        indent("//"),
+        ...traitLines.map((line) => indent(line)),
         `}`,
     ]
         .map((b) => indent(b))

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -138,6 +138,64 @@ $models = new class($factory) {
         return \\Illuminate\\Support\\Str::start($parent, '\\\\');
     }
 
+    protected function collectTraitUseAnnotations(\\ReflectionClass $reflection)
+    {
+        $fileName = $reflection->getFileName();
+
+        if (!$fileName || !file_exists($fileName)) {
+            return [];
+        }
+
+        $source = file_get_contents($fileName);
+
+        $imports = [];
+        $classPos = preg_match('/^\\s*(?:abstract\\s+|final\\s+|readonly\\s+)*class\\s+/m', $source, $classMatch, PREG_OFFSET_CAPTURE)
+            ? $classMatch[0][1]
+            : strlen($source);
+
+        $headerSource = substr($source, 0, $classPos);
+
+        if (preg_match_all('/^\\s*use\\s+([\\w\\\\\\\\]+?)(?:\\s+as\\s+(\\w+))?\\s*;/m', $headerSource, $importMatches, PREG_SET_ORDER)) {
+            foreach ($importMatches as $im) {
+                $fqcn = $im[1];
+                $alias = $im[2] ?? substr(strrchr($fqcn, '\\\\'), 1) ?: $fqcn;
+                $imports[$alias] = $fqcn;
+            }
+        }
+
+        $traitUses = [];
+        $bodySource = substr($source, $classPos);
+
+        if (preg_match_all('/\\/\\*\\*(?:[^*]|\\*(?!\\/))*?@use\\s+([^\\s*]+)(?:[^*]|\\*(?!\\/))*?\\*\\/\\s*\\n\\s*use\\s+([^;]+);/m', $bodySource, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $annotation = trim($match[1]);
+                $traits = trim($match[2]);
+
+                $resolvedAnnotation = preg_replace_callback('/^([\\w]+)/', function ($m) use ($imports) {
+                    return isset($imports[$m[1]])
+                        ? '\\\\' . $imports[$m[1]]
+                        : $m[1];
+                }, $annotation);
+
+                $resolvedTraits = collect(explode(',', $traits))
+                    ->map(function ($trait) use ($imports) {
+                        $trait = trim($trait);
+                        return isset($imports[$trait])
+                            ? '\\\\' . $imports[$trait]
+                            : $trait;
+                    })
+                    ->implode(', ');
+
+                $traitUses[] = [
+                    'annotation' => $resolvedAnnotation,
+                    'traits' => $resolvedTraits,
+                ];
+            }
+        }
+
+        return $traitUses;
+    }
+
     protected function getInfo($className)
     {
         if (($data = $this->fromArtisan($className)) === null) {
@@ -175,6 +233,8 @@ $models = new class($factory) {
             ->toArray();
 
         $data['path'] = LaravelVsCode::relativePath($reflection->getFileName() ?: '');
+
+        $data['traitUses'] = $this->collectTraitUseAnnotations($reflection);
 
         return [
             $className => $data,


### PR DESCRIPTION
[631](https://github.com/laravel/vs-code-extension/issues/631)
Parse and expose @use trait-use annotations from model source files. Adds collectTraitUseAnnotations to php-templates/models.php and the templates/models.ts generation to resolve imported trait names (including aliased imports) and return an array of {annotation, traits}. Populates data.traitUses in model info, updates TypeScript types (TraitUse) and updates docblock generation (src/support/docblocks.ts) to emit /** @use ... */ and corresponding use ...; lines so editors/IDE integrations can surface trait-provided members.