### PR TITLE
Feat/make view extends select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1000,6 +1000,11 @@
                 "command": "laravel.docker.configure",
                 "title": "Configure Docker Environment",
                 "category": "Laravel"
+            },
+            {
+                "command": "laravel.createViewWithExtends",
+                "title": "Create View with Extends",
+                "category": "Laravel"
             }
         ],
         "configuration": {

--- a/src/artisan/commands/ViewMakeCommand.ts
+++ b/src/artisan/commands/ViewMakeCommand.ts
@@ -1,5 +1,6 @@
 import { Command } from "../types";
 import { forceOption, testOptions } from "@src/artisan/options";
+import { getViewKeys } from "@src/repositories/views";
 
 export const ViewMakeCommand: Command = {
     name: "make:view",
@@ -11,5 +12,14 @@ export const ViewMakeCommand: Command = {
             description: "The name of the view",
         },
     ],
-    options: [...testOptions, forceOption],
+    options: [
+        {
+            name: "--extends",
+            type: "select",
+            options: () => getViewKeys(),
+            description: "The parent view to extend",
+        },
+        ...testOptions,
+        forceOption,
+    ],
 };

--- a/src/commands/generatedRegisteredCommands.ts
+++ b/src/commands/generatedRegisteredCommands.ts
@@ -76,4 +76,5 @@ export type RegisteredCommand =
     | "laravel.artisan.cacheClear"
     | "laravel.artisan.vendorPublish"
     | "laravel.docker.configure"
+    | "laravel.createViewWithExtends"
     | "laravel.open";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,10 +272,15 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             commandName("laravel.createViewWithExtends"),
             async (fileUri: vscode.Uri) => {
-                const views = (await import("./repositories/views.js")).getViewKeys();
+                const views = (
+                    await import("./repositories/views.js")
+                ).getViewKeys();
                 const layout = await vscode.window.showQuickPick(
                     Object.keys(views),
-                    { placeHolder: "Select a layout to extend (Escape to skip)" },
+                    {
+                        placeHolder:
+                            "Select a layout to extend (Escape to skip)",
+                    },
                 );
 
                 const content = layout

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,6 +269,28 @@ export async function activate(context: vscode.ExtensionContext) {
             htmlClassToBladeDirectiveCommands.all,
             refactorAllHtmlClassesToBladeDirectives,
         ),
+        vscode.commands.registerCommand(
+            commandName("laravel.createViewWithExtends"),
+            async (fileUri: vscode.Uri) => {
+                const layout = await vscode.window.showInputBox({
+                    prompt: "Layout to extend (press Enter to skip)",
+                    placeHolder: "layouts.app",
+                });
+
+                const content = layout
+                    ? `@extends('${layout}')\n\n@section('content')\n\n@endsection\n`
+                    : "";
+
+                const edit = new vscode.WorkspaceEdit();
+                edit.createFile(fileUri, {
+                    overwrite: false,
+                    contents: Buffer.from(content),
+                });
+
+                await vscode.workspace.applyEdit(edit);
+                await vscode.window.showTextDocument(fileUri);
+            },
+        ),
         ...registerArtisanMakeCommands(),
         ...registerArtisanCommands(),
         vscode.commands.registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,10 +272,11 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             commandName("laravel.createViewWithExtends"),
             async (fileUri: vscode.Uri) => {
-                const layout = await vscode.window.showInputBox({
-                    prompt: "Layout to extend (press Enter to skip)",
-                    placeHolder: "layouts.app",
-                });
+                const views = (await import("./repositories/views.js")).getViewKeys();
+                const layout = await vscode.window.showQuickPick(
+                    Object.keys(views),
+                    { placeHolder: "Select a layout to extend (Escape to skip)" },
+                );
 
                 const content = layout
                     ? `@extends('${layout}')\n\n@section('content')\n\n@endsection\n`

--- a/src/features/view.ts
+++ b/src/features/view.ts
@@ -192,8 +192,8 @@ export const codeActionProvider: CodeActionProviderFunction = async (
         ),
     );
 
+    // Action existante — vue vide
     const edit = new vscode.WorkspaceEdit();
-
     edit.createFile(fileUri, {
         overwrite: false,
         contents: Buffer.from(""),
@@ -208,9 +208,20 @@ export const codeActionProvider: CodeActionProviderFunction = async (
     action.isPreferred = true;
     action.command = openFile(fileUri, 1, 0);
 
-    return [action];
-};
+    // Nouvelle action — vue avec @extends
+    const actionWithExtends = new vscode.CodeAction(
+        "Create missing view extending a layout",
+        vscode.CodeActionKind.QuickFix,
+    );
+    actionWithExtends.diagnostics = [diagnostic];
+    actionWithExtends.command = {
+        command: "laravel.createViewWithExtends",
+        title: "Create missing view extending a layout",
+        arguments: [fileUri],
+    };
 
+    return [action, actionWithExtends];
+};
 const getCompletionItem = (
     view: ViewItem,
     document: vscode.TextDocument,

--- a/src/repositories/views.ts
+++ b/src/repositories/views.ts
@@ -27,3 +27,9 @@ export const getViews = repository<ViewItem[]>({
     itemsDefault: [],
     fileWatcherEvents: ["create", "delete", "change"],
 });
+
+export const getViewKeys = (): Record<string, string> => {
+    return Object.fromEntries(
+        getViews().items.map((view) => [view.key, view.key]),
+    );
+};


### PR DESCRIPTION
## Add layout inheritance when creating a view

When you create a new Blade view in a Laravel project, the first thing you almost always do is open the file and manually type `@extends('layouts.app')`, `@section('content')`, and `@endsection`. Every time. It's a small thing, but it adds up.
This PR lets you skip that step ,whether you're creating a view from the command palette or through the quick fix on an unknown view, you now get a layout picker that shows all the views already in your project. Pick one and the file is generated with the boilerplate ready to go. Press Escape and you get an empty file, same as before.

