### PR TITLE
Add support for model paths configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1064,6 +1064,13 @@
                     "default": true,
                     "description": "Automatically generate Eloquent doc blocks for models as IDE helpers."
                 },
+                "Laravel.eloquent.modelPaths": {
+                    "type": "array",
+                    "default": [
+                        "app/Models"
+                    ],
+                    "description": "Directory paths or glob patterns for model files, relative to the project root."
+                },
                 "Laravel.pest.generateDocBlocks": {
                     "type": "boolean",
                     "default": true,

--- a/php-templates/models.php
+++ b/php-templates/models.php
@@ -54,11 +54,16 @@ $models = new class($factory) {
 
     public function all()
     {
-        if (\Illuminate\Support\Facades\File::isDirectory(base_path('app/Models'))) {
-            collect(\Illuminate\Support\Facades\File::allFiles(base_path('app/Models')))
-                ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
-                ->each(fn($file) => include_once($file));
-        }
+        collect(__VSCODE_LARAVEL_MODEL_PATHS__)
+            ->flatMap(function ($path) {
+                try {
+                    return \Illuminate\Support\Facades\File::allFiles(base_path($path));
+                } catch (\Symfony\Component\Finder\Exception\DirectoryNotFoundException) {
+                    return [];
+                }
+            })
+            ->filter(fn(\Symfony\Component\Finder\SplFileInfo $file) => $file->getExtension() === 'php')
+            ->each(fn($file) => include_once($file));
 
         return collect(get_declared_classes())
             ->filter(fn($class) => is_subclass_of($class, \Illuminate\Database\Eloquent\Model::class))

--- a/src/repositories/models.ts
+++ b/src/repositories/models.ts
@@ -3,8 +3,9 @@ import { Eloquent } from "..";
 import { writeEloquentDocBlocks } from "../support/docblocks";
 import { runInLaravel, template } from "./../support/php";
 import { escapeNamespace } from "../support/util";
+import { config } from "@src/support/config";
 
-const modelPaths = ["app", "app/Models"];
+const modelPaths = config("eloquent.modelPaths", ["app/Models"]);
 
 const load = () => {
     return runInLaravel<Eloquent.Result>(

--- a/src/support/config.ts
+++ b/src/support/config.ts
@@ -12,6 +12,7 @@ type ConfigKey =
     | "showErrorPopups"
     | "blade.autoSpaceTags"
     | "eloquent.generateDocBlocks"
+    | "eloquent.modelPaths"
     | "pest.generateDocBlocks"
     | "pest.helperFilePath"
     | "env.viteQuickFix"

--- a/src/templates/models.ts
+++ b/src/templates/models.ts
@@ -54,11 +54,16 @@ $models = new class($factory) {
 
     public function all()
     {
-        if (\\Illuminate\\Support\\Facades\\File::isDirectory(base_path('app/Models'))) {
-            collect(\\Illuminate\\Support\\Facades\\File::allFiles(base_path('app/Models')))
-                ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
-                ->each(fn($file) => include_once($file));
-        }
+        collect(__VSCODE_LARAVEL_MODEL_PATHS__)
+            ->flatMap(function ($path) {
+                try {
+                    return \\Illuminate\\Support\\Facades\\File::allFiles(base_path($path));
+                } catch (\\Symfony\\Component\\Finder\\Exception\\DirectoryNotFoundException) {
+                    return [];
+                }
+            })
+            ->filter(fn(\\Symfony\\Component\\Finder\\SplFileInfo $file) => $file->getExtension() === 'php')
+            ->each(fn($file) => include_once($file));
 
         return collect(get_declared_classes())
             ->filter(fn($class) => is_subclass_of($class, \\Illuminate\\Database\\Eloquent\\Model::class))


### PR DESCRIPTION
This PR adds support for model paths configuration, allowing users to customize search paths for Eloquent models through `Laravel.eloquent.modelPaths` property, with support for glob patterns, so that it is possible to specify paths like `app/Domain/*/Models`.

Closes #500