### PR TITLE
Fix: use relative paths for Laravel Policy URIs

### DIFF
--- a/php-templates/auth.php
+++ b/php-templates/auth.php
@@ -60,7 +60,7 @@ if (!\Illuminate\Support\Facades\App::bound('auth')) {
 
         return collect($methods)->map(fn(ReflectionMethod $method) => [
             'key' => $method->getName(),
-            'uri' => $method->getFileName(),
+            'uri' => LaravelVsCode::relativePath($method->getFileName()),
             'policy' => is_string($policy) ? $policy : get_class($policy),
             'model' => $model,
             'line' => $method->getStartLine(),
@@ -91,7 +91,7 @@ if (!\Illuminate\Support\Facades\App::bound('auth')) {
 
                             return [
                                 'key' => $key,
-                                'uri' => $reflection->getFileName(),
+                                'uri' => LaravelVsCode::relativePath($reflection->getFileName()),
                                 'policy' => $policyClass,
                                 'line' => $reflection->getStartLine(),
                             ];

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -5,6 +5,7 @@ import { config } from "@src/support/config";
 import { findHoverMatchesInDoc } from "@src/support/doc";
 import { detectedRange, detectInDoc } from "@src/support/parser";
 import { wordMatchRegex } from "@src/support/patterns";
+import { projectPath } from "@src/support/project";
 import { contract, facade, relativeMarkdownLink } from "@src/support/util";
 import { AutocompleteParsingResult } from "@src/types";
 import * as vscode from "vscode";
@@ -199,9 +200,11 @@ export const linkProvider: LinkProvider = (doc: vscode.TextDocument) => {
                                     detectedRange(
                                         param as AutocompleteParsingResult.StringValue,
                                     ),
-                                    vscode.Uri.file(item.uri).with({
-                                        fragment: `L${item.line}`,
-                                    }),
+                                    vscode.Uri.file(projectPath(item.uri)).with(
+                                        {
+                                            fragment: `L${item.line}`,
+                                        },
+                                    ),
                                 );
                             },
                         )
@@ -234,7 +237,7 @@ export const hoverProvider: HoverProvider = (
                     return [
                         "`" + item.policy + "`",
                         relativeMarkdownLink(
-                            vscode.Uri.file(item.uri).with({
+                            vscode.Uri.file(projectPath(item.uri)).with({
                                 fragment: `L${item.line}`,
                             }),
                         ),
@@ -242,7 +245,7 @@ export const hoverProvider: HoverProvider = (
                 }
 
                 return relativeMarkdownLink(
-                    vscode.Uri.file(item.uri).with({
+                    vscode.Uri.file(projectPath(item.uri)).with({
                         fragment: `L${item.line}`,
                     }),
                 );

--- a/src/templates/auth.ts
+++ b/src/templates/auth.ts
@@ -60,7 +60,7 @@ if (!\\Illuminate\\Support\\Facades\\App::bound('auth')) {
 
         return collect($methods)->map(fn(ReflectionMethod $method) => [
             'key' => $method->getName(),
-            'uri' => $method->getFileName(),
+            'uri' => LaravelVsCode::relativePath($method->getFileName()),
             'policy' => is_string($policy) ? $policy : get_class($policy),
             'model' => $model,
             'line' => $method->getStartLine(),
@@ -91,7 +91,7 @@ if (!\\Illuminate\\Support\\Facades\\App::bound('auth')) {
 
                             return [
                                 'key' => $key,
-                                'uri' => $reflection->getFileName(),
+                                'uri' => LaravelVsCode::relativePath($reflection->getFileName()),
                                 'policy' => $policyClass,
                                 'line' => $reflection->getStartLine(),
                             ];


### PR DESCRIPTION
Before:

<img width="552" height="186" alt="obraz" src="https://github.com/user-attachments/assets/ca39d2fd-bad0-4b80-9638-7bae3c0adeda" /> <img width="418" height="162" alt="obraz" src="https://github.com/user-attachments/assets/d7f36235-3e2f-41d3-9b7f-9a163c292be6" />

After:

<img width="514" height="198" alt="obraz" src="https://github.com/user-attachments/assets/95b1f04c-e6a2-456b-b8b0-abefcd0e4240" />
