### PR TITLE
LSP: Add LSP trace output for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1049,6 +1049,17 @@
                     },
                     "description": "PHP command used by the Laravel LSP server, Docker environment configuration, Artisan commands, Pint, and test runner, in argv format. Defaults to php when empty."
                 },
+                "laravelLsp.trace.server": {
+                    "scope": "window",
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "description": "Traces the communication between VS Code and the Laravel LSP server."
+                },                
                 "Laravel.basePath": {
                     "type": "string",
                     "default": "",

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -1,4 +1,4 @@
-import type * as vscode from "vscode";
+import * as vscode from "vscode";
 import {
     LanguageClientOptions,
     ServerOptions,
@@ -36,6 +36,8 @@ export function createClientOptions(
             { scheme: "file", language: "laravel-blade" },
             { scheme: "file", pattern: "**/.env*" },
         ],
+        traceOutputChannel:
+            vscode.window.createOutputChannel("Laravel LSP Trace"),
         initializationOptions: {
             appBindingCompletion: config("appBinding.completion", true),
             appBindingDiagnostics: config("appBinding.diagnostics", true),

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 import {
     LanguageClientOptions,
     ServerOptions,

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -1,4 +1,4 @@
-import type * as vscode from "vscode";
+import * as vscode from "vscode";
 import {
     LanguageClientOptions,
     ServerOptions,


### PR DESCRIPTION
This PR adds support for LSP trace output with a configuration option to enable it (message-only or verbose mode).

This is useful for debugging, especially for measuring response times between the server and the client.

Example:

<img width="1315" height="894" alt="obraz" src="https://github.com/user-attachments/assets/85233c24-3cdb-4c12-8961-28c784a000d8" />
