### PR TITLE
LSP: Fix the Artisan make command when using a namespace as an argument

### DIFF
--- a/src/artisan/builder.ts
+++ b/src/artisan/builder.ts
@@ -2,7 +2,6 @@ import path from "path";
 import * as vscode from "vscode";
 
 import { getNamespace } from "@src/commands/generateNamespace";
-import { escapeNamespace } from "@src/support/util";
 import { Argument, ArgumentType, Command, Option } from "./types";
 
 const EndSelection = "End Selection";

--- a/src/artisan/builder.ts
+++ b/src/artisan/builder.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
 import path from "path";
+import * as vscode from "vscode";
 
 import { getNamespace } from "@src/commands/generateNamespace";
 import { escapeNamespace } from "@src/support/util";
@@ -43,7 +43,7 @@ const getValueForArgumentType = async (
 
             namespace = namespace ? (namespace += `\\${fileName}`) : value;
 
-            return escapeNamespace(namespace.replaceAll("/", "\\").trim());
+            return namespace.replaceAll("/", "\\").trim();
 
         case "path":
             // OS path separators

--- a/src/lsp/models.ts
+++ b/src/lsp/models.ts
@@ -17,7 +17,7 @@ export const getModelClassnames = async (): Promise<Record<string, string>> => {
     return Object.fromEntries(
         Object.values(await getModels()).map((model) => [
             model.class,
-            escapeNamespace(model.class),
+            model.class,
         ]),
     );
 };

--- a/src/lsp/models.ts
+++ b/src/lsp/models.ts
@@ -1,4 +1,3 @@
-import { escapeNamespace } from "@src/support/util";
 import { sendLspRequest } from "./client";
 
 interface ModelItem {

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -150,16 +150,3 @@ export const createIndexMapping = (
         },
     };
 };
-
-export const escapeNamespace = (namespace: string): string => {
-    if (
-        ["linux", "openbsd", "sunos", "darwin"].some((unixPlatforms) =>
-            os.platform().includes(unixPlatforms),
-        )
-    ) {
-        // We need to escape backslashes because finally it will be a part of CLI command
-        return namespace.replace(/(?<!\\)\\(?!\\)/g, "\\\\");
-    }
-
-    return namespace;
-};


### PR DESCRIPTION
In the `lsp` branch, the [`artisan`](https://github.com/laravel/vs-code-extension/blob/lsp/src/support/php.ts#L36) function uses `execFile` instead of [`exec`](https://github.com/laravel/vs-code-extension/blob/main/src/support/php.ts#L329) as in the `main` branch, so we shouldn't manually escape any command arguments (such as class namespaces) because of this:

<img width="573" height="368" alt="obraz" src="https://github.com/user-attachments/assets/fc762110-6893-49e1-be9a-9718c6b44360" />

This PR fixes this issue and removes the unnecessary `escapeNamespace` function.