### PR TITLE
Fix - Pest helper syntax errors by sanitizing generated TestCase namespace segments

### DIFF
--- a/src/features/pest.ts
+++ b/src/features/pest.ts
@@ -173,6 +173,15 @@ const renderPestDocBlockFile = (blocks: string[]): string => {
 
 const pestNamespace = (filePath: string): string => {
     const relative = filePath.replace(/^tests[/\\]?/, "");
-    const segment = relative ? relative.replace(/[/\\]/g, "\\") : "Global";
-    return `_Pest\\${segment}`;
+    if (!relative) {
+        return "_Pest\\Global";
+    }
+
+    const segments = relative.split(/[/\\]/);
+    const sanitizedSegments = segments
+        .map((segment) => segment.replace(/[^a-zA-Z0-9_\x7f-\xff]/g, "_"))
+        .map((segment) => (/^[0-9]/.test(segment) ? `_${segment}` : segment))
+        .filter((segment) => segment.length > 0);
+
+    return `_Pest\\${sanitizedSegments.join("\\")}`;
 };


### PR DESCRIPTION
## Description
This PR fixes a syntax error bug in the dynamically generated Pest helper file (`storage/framework/testing/_pest.php`). 

When test configuration files or packages reside in subdirectories or contain characters like hyphens (`-`), dots (`.`), or start with digits, the extension generates invalid PHP namespace declarations. This causes IDE parser failures in tools like PHP Intelephense, PHP Tools, or PHPStan, breaking autocomplete for Pest's functional test helpers (`beforeEach()`, `afterEach()`, `test()`, and `it()`).

---

## The Problem & Cause
Pest test configurations are mapped to virtual `TestCase` classes containing the bound traits. These are written inside `_pest.php` to define the `$this` closure context for IDE parsing. 

In `src/features/pest.ts`, the `pestNamespace` helper converted relative file paths directly to namespace segments:
```typescript
const pestNamespace = (filePath: string): string => {
    const relative = filePath.replace(/^tests[/\\]?/, "");
    const segment = relative ? relative.replace(/[/\\]/g, "\\") : "Global";
    return `_Pest\\${segment}`;
};
```

If a test file path was e.g. `vendor/_laravel_ide/discover-bf37f1dc35944596ec71c910bc1ca84f.php`, it yielded:
```php
namespace _Pest\vendor\_laravel_ide\discover-bf37f1dc35944596ec71c910bc1ca84f.php {
    class TestCase {
        use \Illuminate\Foundation\Testing\RefreshDatabase;
    }
}
```
PHP namespaces do not allow hyphens (`-`), dots (`.`), or starting segments with numbers. The above code causes parser crashes in the language server, disabling helper type-hints in the IDE.

---

## The Fix
We updated the `pestNamespace` function in `src/features/pest.ts` to sanitize each segment of the path:
1. Split the relative path by path separators (`/` or `\`).
2. Replace all non-alphanumeric and non-underscore characters (`[^a-zA-Z0-9_\x7f-\xff]`) with underscores (`_`).
3. Prepend a leading underscore (`_`) if the segment begins with a digit (which is illegal for PHP identifiers).
4. Filter out empty segments and join them with `\`.

### Before / After Example:
* **File Path:** `vendor/_laravel_ide/discover-bf37f1dc35944596ec71c910bc1ca84f.php`
* **Before:** `_Pest\vendor\_laravel_ide\discover-bf37f1dc35944596ec71c910bc1ca84f.php` (invalid PHP syntax)
* **After:** `_Pest\vendor\_laravel_ide\discover_bf37f1dc35944596ec71c910bc1ca84f_php` (valid PHP syntax)

---

## Benefits & Impact
* **Restored Autocomplete:** Prevents syntax errors in `_pest.php`, allowing IDE Language Servers to parse the helper correctly and restore auto-completions on `$this` context in Pest tests.
* **Fully Compatible:** Retains unique virtual namespaces per test file/path, ensuring proper trait imports mapping.
* **Robust Identifier Generation:** Safely handles file paths containing numbers, hyphens, and dot-extensions.