### PR TITLE
Fix: typo mimimal to minimal in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -49,6 +49,6 @@ body:
     - type: textarea
       id: code_sample
       attributes:
-          label: Mimimal Code Sample
+          label: Minimal Code Sample
           description: If you can, please provide a minimal code sample that reproduces the bug.
           render: php


### PR DESCRIPTION
 Fixes a small typo in the bug report issue template.

  The "Minimal Code Sample" field label was misspelled as "Mimimal".
  Since this label is rendered into every new bug report from the
  template, the typo currently shows up on all filed issues.

  ### Change
  - `.github/ISSUE_TEMPLATE/bug.yml`: `Mimimal Code Sample` → `Minimal Code Sample`

  No code or behavior changes.