### PR TITLE
Add Lerd support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1014,6 +1014,7 @@
                         "sail",
                         "lando",
                         "ddev",
+                        "lerd",
                         "local",
                         "docker"
                     ],
@@ -1024,6 +1025,7 @@
                         "Sail",
                         "Lando",
                         "DDEV",
+                        "Lerd",
                         "Local",
                         "Docker"
                     ],
@@ -1034,6 +1036,7 @@
                         "Sail",
                         "Lando",
                         "DDEV",
+                        "Auto detect the PHP version Lerd is using for the project.",
                         "Use PHP installed on the local machine.",
                         "Docker"
                     ],

--- a/src/support/phpEnvironments.ts
+++ b/src/support/phpEnvironments.ts
@@ -16,6 +16,7 @@ export type PhpEnvironment =
     | "sail"
     | "lando"
     | "ddev"
+    | "lerd"
     | "docker"
     | "local";
 
@@ -53,6 +54,13 @@ export const phpEnvironments: Record<PhpEnvironment, PhpEnvironmentConfig> = {
         label: "DDEV",
         check: 'ddev php -r "echo PHP_BINARY;"',
         command: "ddev php",
+        relativePath: true,
+    },
+    lerd: {
+        label: "Lerd",
+        description: "Auto detect the PHP version Lerd is using for the project.",
+        check: 'lerd php -r "echo PHP_BINARY;"',
+        command: "lerd php",
         relativePath: true,
     },
     local: {


### PR DESCRIPTION
Adds [Lerd](https://lerd.sh) to the list of detectable PHP environments, alongside Sail, Lando, and DDEV.

Lerd is an open-source, Herd-like local PHP development environment for Linux and macOS that runs Nginx, PHP-FPM, and services as rootless Podman containers. It exposes `lerd php` to run PHP inside a project's container, which is all the extension needs to resolve the environment.

The entry follows the existing containerized pattern:

- `check`: `lerd php -r "echo PHP_BINARY;"` to detect that Lerd manages the project
- `command`: `lerd php`
- `relativePath: true`, since PHP runs inside a container

One simplification worth noting: Lerd bind-mounts the project at its identical host path and runs `lerd php` with the container working directory set to the project root, so host and container paths line up 1:1. That means Lerd needs no entry in `pathForPhpEnv`, unlike DDEV which strips its `/var/www/html/` prefix.

The `Laravel.phpEnvironment` enum, labels, and descriptions in `package.json` are updated to match, mirroring what `generate-php-envs.php` produces from the new entry.
