### PR TITLE
Automatically update the Laravel LSP binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -698,6 +698,11 @@
                 "category": "Laravel"
             },
             {
+                "command": "laravel.lsp.update",
+                "title": "Update LSP",
+                "category": "Laravel"
+            },
+            {
                 "command": "laravel.artisan.make.cast",
                 "title": "Make Cast",
                 "category": "Laravel"

--- a/release.sh
+++ b/release.sh
@@ -18,15 +18,6 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 
-BINARY_VERSION=`grep 'const binaryVersion' src/lsp/binary.ts | sed -E 's/.*"([^"]+)".*/\1/'`
-
-read -p "Correct binary version (y/n)? $BINARY_VERSION " confirmation
-
-if [ "$confirmation" != "y" ]; then
-  echo "Please update the binary version in src/lsp/binary.ts"
-  exit 1
-fi
-
 echo
 echo "Current version: $(node -p "require('./package.json').version")"
 echo

--- a/src/commands/generatedRegisteredCommands.ts
+++ b/src/commands/generatedRegisteredCommands.ts
@@ -15,6 +15,7 @@ export type RegisteredCommand =
     | "laravel.refactorAllHtmlClassesToBladeDirectives"
     | "laravel.namespace.generate"
     | "laravel.goToRoute"
+    | "laravel.lsp.update"
     | "laravel.artisan.make.cast"
     | "laravel.artisan.make.channel"
     | "laravel.artisan.make.class"

--- a/src/downloaders/FileDownloader.ts
+++ b/src/downloaders/FileDownloader.ts
@@ -38,6 +38,36 @@ export class FileDownloader implements IFileDownloader {
         );
     }
 
+    public async getLatestGitHubRelease(
+        owner: string,
+        repository: string,
+    ): Promise<IGithubRelease | undefined> {
+        const headers: Record<string, string> = {
+            Accept: `application/vnd.github+json`,
+        };
+
+        try {
+            const response: AxiosResponse<IGithubRelease> = await axios.get(
+                `https://api.github.com/repos/${owner}/${repository}/releases/latest`,
+                {
+                    headers,
+                    proxy: false,
+                    timeout: DefaultTimeoutInMs,
+                },
+            );
+
+            return response.data;
+        } catch (error) {
+            this._logger.error(
+                `Failed to access https://api.github.com/repos/${owner}/${repository}/releases/latest. Technical details: ${JSON.stringify(
+                    error,
+                )}`,
+            );
+        }
+
+        return undefined;
+    }
+
     /**
      * @param settings optional additional settings for the download. If this is not provided, we will set the Accept header
      * to application/octet-stream.
@@ -74,14 +104,6 @@ export class FileDownloader implements IFileDownloader {
             };
         } else if (settings.headers.Accept === undefined) {
             settings.headers.Accept = `application/octet-stream`;
-        }
-
-        // If the GITHUB_TOKEN is set, then use it to download the file
-        // and then we wont get rate limited.
-        const token = process.env.GITHUB_TOKEN;
-        if (token !== null) {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            settings.headers.Authorization = `Bearer ${token}`;
         }
 
         return this.downloadFile(
@@ -360,22 +382,14 @@ export class FileDownloader implements IFileDownloader {
         repository: string,
         fileName: string,
     ): Promise<Uri | undefined> {
-        try {
-            const response: AxiosResponse<IGithubRelease> = await axios.get(
-                `https://api.github.com/repos/${owner}/${repository}/releases/latest`,
-            );
-            for (const asset of response.data.assets) {
+        const release = await this.getLatestGitHubRelease(owner, repository);
+
+        if (release) {
+            for (const asset of release.assets) {
                 if (asset.name === fileName) {
                     return Uri.parse(asset.url);
                 }
             }
-        } catch (error) {
-            // Maybe GitHub is down, don't stop the extension from working.
-            this._logger.error(
-                `Failed to access https://api.github.com/repos/${owner}/${repository} for ${fileName}. Technical details: ${JSON.stringify(
-                    error,
-                )}`,
-            );
         }
 
         this._logger.error(`${fileName} not found in latest release.`);

--- a/src/downloaders/IFileDownloader.ts
+++ b/src/downloaders/IFileDownloader.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { CancellationToken, ExtensionContext, Uri } from "vscode";
+import { IGithubRelease } from "./IGitHubRelease";
 
 export interface FileDownloadSettings {
     /**
@@ -41,6 +42,13 @@ export interface FileDownloadSettings {
 }
 
 export interface IFileDownloader {
+    /**
+     * Gets the latest stable, published release for a GitHub repository.
+     */
+    getLatestGitHubRelease(
+        owner: string,
+        repository: string,
+    ): Promise<IGithubRelease | undefined>;
     /**
      * Downloads a file from a URL and gives back the file path, file name, and a checksum. Allows you to specify the
      * timeout, the number of acceptable retries, whether or not to unzip the file, and whether or not to check the

--- a/src/downloaders/IGitHubRelease.ts
+++ b/src/downloaders/IGitHubRelease.ts
@@ -21,7 +21,7 @@ export interface IGithubRelease {
     mentions_count: number;
 }
 
-interface IAsset {
+export interface IAsset {
     url: string;
     id: number;
     node_id: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,7 @@ import { info } from "./support/logger";
 import { restartLspClient, startLspClient, stopLspClient } from "./lsp/client";
 import { setLspBinaryPath } from "./lsp/binary";
 import { clearResolvedPhpCommand, warnAboutLegacyPhpCommand } from "./lsp/php";
+import { checkForLspUpdate, forceLspUpdate } from "./lsp/updater";
 import { hasWorkspace, projectPathExists } from "./support/project";
 import { cleanUpTemp } from "./support/util";
 import {
@@ -92,6 +93,9 @@ export async function activate(context: vscode.ExtensionContext) {
             commandName("laravel.goToRoute"),
             goToRouteCommand,
         ),
+        vscode.commands.registerCommand(commandName("laravel.lsp.update"), () =>
+            forceLspUpdate(context, shouldActivate()),
+        ),
     );
 
     if (!shouldActivate()) {
@@ -118,6 +122,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
         registerTestRunner();
     }
+
+    void checkForLspUpdate(context);
 
     console.log("Laravel VS Code Started...");
 

--- a/src/lsp/binary.ts
+++ b/src/lsp/binary.ts
@@ -1,63 +1,165 @@
-import { FileDownloader } from "@src/downloaders/FileDownloader";
-import OutputLogger from "@src/downloaders/logging/OutputLogger";
-import HttpRequestHandler from "@src/downloaders/networking/HttpRequestHandler";
-import * as cp from "child_process";
+import { FileDownloader } from "../downloaders/FileDownloader";
+import { IAsset } from "../downloaders/IGitHubRelease";
+import OutputLogger from "../downloaders/logging/OutputLogger";
+import HttpRequestHandler from "../downloaders/networking/HttpRequestHandler";
+import * as fs from "fs";
 import * as os from "os";
+import * as path from "path";
 import * as vscode from "vscode";
 
+const LAST_UPDATE_CHECK_KEY = "laravel.lsp.lastUpdateCheck";
+export const LSP_UPDATE_THROTTLE_MS = 2 * 60 * 60 * 1000;
+
 let lspBinaryPath: string | undefined = process.env.LARAVEL_LSP_BINARY_PATH;
-let lspBinaryPathReady: Promise<string | undefined>;
+let lspBinaryPathReady: Promise<string | undefined> =
+    Promise.resolve(lspBinaryPath);
+let fileDownloader: FileDownloader | undefined;
+let updateQueue: Promise<void> = Promise.resolve();
+
+export type LspBinaryUpdateResult =
+    | {
+          status: "updated";
+          path: string;
+          previousPath?: string;
+          backupPath?: string;
+      }
+    | {
+          status: "current" | "throttled";
+          path?: string;
+      }
+    | {
+          status: "custom";
+          path: string;
+      };
 
 export const getLspBinaryPath = (): Promise<string | undefined> => {
     return lspBinaryPathReady;
 };
 
-export const setLspBinaryPath = (context: vscode.ExtensionContext) => {
-    if (lspBinaryPath) {
-        lspBinaryPathReady = Promise.resolve(lspBinaryPath);
+export const isUsingCustomLspBinary = (): boolean => {
+    return process.env.LARAVEL_LSP_BINARY_PATH !== undefined;
+};
+
+export const shouldCheckForLspUpdate = (
+    lastCheck: number | undefined,
+    now: number = Date.now(),
+): boolean => {
+    return lastCheck === undefined || now - lastCheck >= LSP_UPDATE_THROTTLE_MS;
+};
+
+export const findLspReleaseAsset = (
+    assets: Pick<IAsset, "name" | "browser_download_url">[],
+    platform: NodeJS.Platform = os.platform(),
+    arch: string = os.arch(),
+): Pick<IAsset, "name" | "browser_download_url"> | undefined => {
+    const extension = platform === "win32" ? ".exe" : "";
+    const suffix = `-${arch}-${platform}${extension}`;
+
+    return assets.find(
+        (asset) =>
+            asset.name.startsWith("server-v") && asset.name.endsWith(suffix),
+    );
+};
+
+export const findCachedLspBinary = (
+    files: vscode.Uri[],
+    platform: NodeJS.Platform = os.platform(),
+    arch: string = os.arch(),
+): vscode.Uri | undefined => {
+    const extension = platform === "win32" ? ".exe" : "";
+    const suffix = `-${arch}-${platform}${extension}`;
+
+    return files
+        .filter((file) => {
+            const filename = path.basename(file.fsPath);
+
+            return filename.startsWith("server-v") && filename.endsWith(suffix);
+        })
+        .sort((left, right) =>
+            path
+                .basename(right.fsPath)
+                .localeCompare(path.basename(left.fsPath), undefined, {
+                    numeric: true,
+                }),
+        )[0];
+};
+
+export const setLspBinaryPath = (context: vscode.ExtensionContext): void => {
+    if (isUsingCustomLspBinary()) {
+        setActiveLspBinaryPath(process.env.LARAVEL_LSP_BINARY_PATH);
         return;
     }
 
-    lspBinaryPathReady = downloadBinary(context).then((path) => {
-        if (path) {
-            lspBinaryPath = process.env.LARAVEL_LSP_BINARY_PATH || path;
-        }
-
-        return lspBinaryPath;
-    });
+    lspBinaryPathReady = initializeLspBinaryPath(context);
 };
 
-const downloadBinary = async (context: vscode.ExtensionContext) => {
-    const binaryVersion = "0.0.27";
-    const osPlatform = os.platform();
-    const osArch = os.arch();
-    const extension = osPlatform === "win32" ? ".exe" : "";
-    const filename = `server-v${binaryVersion}-${osArch}-${osPlatform}${extension}`;
+export const updateLspBinary = (
+    context: vscode.ExtensionContext,
+    options: { force?: boolean } = {},
+): Promise<LspBinaryUpdateResult> => {
+    const update = updateQueue.then(() =>
+        performLspBinaryUpdate(context, options.force ?? false),
+    );
 
-    const uri = `https://github.com/laravel/lsp/releases/download/v${binaryVersion}/${filename}`;
+    updateQueue = update.then(
+        () => undefined,
+        () => undefined,
+    );
 
-    const logger = new OutputLogger(`File Downloader`, context);
-    const requestHandler = new HttpRequestHandler(logger);
-    const fileDownloader = new FileDownloader(requestHandler, logger);
+    return update;
+};
 
-    const downloadedFiles: vscode.Uri[] =
-        await fileDownloader.listDownloadedItems(context);
-
-    for (const file of downloadedFiles) {
-        if (!file.fsPath.includes(filename)) {
-            const filename = file.path.split("/").pop();
-
-            if (filename !== undefined) {
-                await fileDownloader.deleteItem(filename, context);
-            }
-        }
+export const completeLspBinaryUpdate = async (
+    context: vscode.ExtensionContext,
+    result: LspBinaryUpdateResult,
+): Promise<void> => {
+    if (result.status !== "updated") {
+        return;
     }
 
-    const downloadedFile: vscode.Uri | undefined =
-        await fileDownloader.tryGetItem(filename, context);
+    const downloader = getFileDownloader(context);
+    const files = await downloader.listDownloadedItems(context);
 
-    if (downloadedFile !== undefined) {
-        return downloadedFile.fsPath;
+    for (const file of files) {
+        const filename = path.basename(file.fsPath);
+
+        if (filename.startsWith("server-v") && file.fsPath !== result.path) {
+            await downloader.deleteItem(filename, context);
+        }
+    }
+};
+
+export const rollbackLspBinaryUpdate = async (
+    context: vscode.ExtensionContext,
+    result: LspBinaryUpdateResult,
+): Promise<void> => {
+    if (result.status !== "updated") {
+        return;
+    }
+
+    const downloader = getFileDownloader(context);
+
+    if (result.backupPath) {
+        await downloader.deleteItem(path.basename(result.path), context);
+        await fs.promises.rename(result.backupPath, result.path);
+    } else if (result.path !== result.previousPath) {
+        await downloader.deleteItem(path.basename(result.path), context);
+    }
+
+    setActiveLspBinaryPath(result.previousPath);
+};
+
+const initializeLspBinaryPath = async (
+    context: vscode.ExtensionContext,
+): Promise<string | undefined> => {
+    const downloader = getFileDownloader(context);
+    const cachedBinary = findCachedLspBinary(
+        await downloader.listDownloadedItems(context),
+    );
+
+    if (cachedBinary) {
+        setActiveLspBinaryPath(cachedBinary.fsPath);
+        return cachedBinary.fsPath;
     }
 
     vscode.window.showInformationMessage(
@@ -65,29 +167,143 @@ const downloadBinary = async (context: vscode.ExtensionContext) => {
     );
 
     try {
-        const file: vscode.Uri = await fileDownloader.downloadFile(
-            vscode.Uri.parse(uri),
-            filename,
-            context,
-            undefined,
-            undefined,
-            {
-                timeoutInMs: 300_000,
-            },
-        );
+        const result = await updateLspBinary(context, { force: true });
 
-        if (osPlatform !== "win32") {
-            cp.execSync(`chmod +x "${file.fsPath}"`);
+        if (result.status === "updated") {
+            await completeLspBinaryUpdate(context, result);
+            vscode.window.showInformationMessage(
+                "Binary downloaded for Laravel extension",
+            );
+
+            return result.path;
         }
 
-        vscode.window.showInformationMessage(
-            "Binary downloaded for Laravel extension",
-        );
-
-        return file.fsPath;
-    } catch (e) {
+        return result.path;
+    } catch (error) {
         vscode.window.showErrorMessage(
-            `Failed to download binary for Laravel extension: ${filename}`,
+            `Failed to download binary for Laravel extension: ${errorMessage(error)}`,
         );
     }
+
+    return undefined;
+};
+
+const performLspBinaryUpdate = async (
+    context: vscode.ExtensionContext,
+    force: boolean,
+): Promise<LspBinaryUpdateResult> => {
+    if (isUsingCustomLspBinary()) {
+        return {
+            status: "custom",
+            path: process.env.LARAVEL_LSP_BINARY_PATH!,
+        };
+    }
+
+    const lastCheck = context.globalState.get<number>(LAST_UPDATE_CHECK_KEY);
+
+    if (!force && !shouldCheckForLspUpdate(lastCheck)) {
+        return { status: "throttled", path: lspBinaryPath };
+    }
+
+    await context.globalState.update(LAST_UPDATE_CHECK_KEY, Date.now());
+
+    const downloader = getFileDownloader(context);
+    const release = await downloader.getLatestGitHubRelease("laravel", "lsp");
+
+    if (!release) {
+        throw new Error("Unable to retrieve the latest Laravel LSP release");
+    }
+
+    const asset = findLspReleaseAsset(release.assets);
+
+    if (!asset) {
+        throw new Error(
+            `The latest Laravel LSP release has no binary for ${os.arch()}-${os.platform()}`,
+        );
+    }
+
+    const downloadedFile = await downloader.tryGetItem(asset.name, context);
+
+    if (downloadedFile && !force) {
+        setActiveLspBinaryPath(downloadedFile.fsPath);
+
+        return { status: "current", path: downloadedFile.fsPath };
+    }
+
+    const previousPath = lspBinaryPath;
+    const pendingFilename = `${asset.name}.pending`;
+    const pendingFile = await downloader.downloadFile(
+        vscode.Uri.parse(asset.browser_download_url),
+        pendingFilename,
+        context,
+        undefined,
+        undefined,
+        {
+            timeoutInMs: 300_000,
+            makeExecutable: os.platform() !== "win32",
+        },
+    );
+    const targetPath = path.join(path.dirname(pendingFile.fsPath), asset.name);
+    const backupPath = `${targetPath}.backup`;
+    let hasBackup = false;
+
+    try {
+        await downloader.deleteItem(path.basename(backupPath), context);
+
+        try {
+            await fs.promises.rename(targetPath, backupPath);
+            hasBackup = true;
+        } catch (error) {
+            if (!isFileNotFoundError(error)) {
+                throw error;
+            }
+        }
+
+        await fs.promises.rename(pendingFile.fsPath, targetPath);
+    } catch (error) {
+        if (hasBackup) {
+            await fs.promises.rename(backupPath, targetPath);
+        }
+
+        throw error;
+    }
+
+    setActiveLspBinaryPath(targetPath);
+
+    return {
+        status: "updated",
+        path: targetPath,
+        previousPath,
+        backupPath: hasBackup ? backupPath : undefined,
+    };
+};
+
+const getFileDownloader = (
+    context: vscode.ExtensionContext,
+): FileDownloader => {
+    if (!fileDownloader) {
+        const logger = new OutputLogger("File Downloader", context);
+        const requestHandler = new HttpRequestHandler(logger);
+        fileDownloader = new FileDownloader(requestHandler, logger);
+    }
+
+    return fileDownloader;
+};
+
+const setActiveLspBinaryPath = (binaryPath: string | undefined): void => {
+    lspBinaryPath = binaryPath;
+    lspBinaryPathReady = Promise.resolve(binaryPath);
+};
+
+const isFileNotFoundError = (error: unknown): boolean => {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+    );
+};
+
+const errorMessage = (error: unknown): string => {
+    return error instanceof Error ? error.message : String(error);
 };

--- a/src/lsp/updater.ts
+++ b/src/lsp/updater.ts
@@ -1,0 +1,144 @@
+import * as vscode from "vscode";
+import {
+    completeLspBinaryUpdate,
+    isUsingCustomLspBinary,
+    LspBinaryUpdateResult,
+    rollbackLspBinaryUpdate,
+    updateLspBinary,
+} from "./binary";
+import { restartLspClient, startLspClient, stopLspClient } from "./client";
+
+let lspUpdateQueue: Promise<void> = Promise.resolve();
+
+export function checkForLspUpdate(
+    context: vscode.ExtensionContext,
+): Promise<void> {
+    return enqueueLspUpdate(() => performLspUpdateCheck(context));
+}
+
+export async function forceLspUpdate(
+    context: vscode.ExtensionContext,
+    isLaravelProject: boolean,
+): Promise<void> {
+    if (!isLaravelProject) {
+        vscode.window.showInformationMessage(
+            "A Laravel project is required to update the Laravel LSP.",
+        );
+        return;
+    }
+
+    if (isUsingCustomLspBinary()) {
+        vscode.window.showInformationMessage(
+            "The Laravel LSP is managed by LARAVEL_LSP_BINARY_PATH and cannot be updated by the extension.",
+        );
+        return;
+    }
+
+    try {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Updating Laravel LSP",
+                cancellable: false,
+            },
+            () =>
+                enqueueLspUpdate(async () => {
+                    let result: LspBinaryUpdateResult | undefined;
+
+                    await stopLspClient();
+
+                    try {
+                        result = await updateLspBinary(context, {
+                            force: true,
+                        });
+
+                        const updatedClient = await startLspClient();
+
+                        if (!updatedClient) {
+                            throw new Error(
+                                "The updated Laravel LSP did not start",
+                            );
+                        }
+                    } catch (error) {
+                        if (result?.status === "updated") {
+                            await rollbackLspBinaryUpdate(context, result);
+                        }
+
+                        await startLspClient();
+                        throw error;
+                    }
+
+                    try {
+                        await completeLspBinaryUpdate(context, result);
+                    } catch (error) {
+                        console.error(
+                            "Failed to clean up old Laravel LSP binaries:",
+                            error,
+                        );
+                    }
+                }),
+        );
+
+        vscode.window.showInformationMessage(
+            "Laravel LSP updated successfully.",
+        );
+    } catch (error) {
+        console.error("Failed to update the Laravel LSP:", error);
+        vscode.window.showErrorMessage(
+            `Failed to update the Laravel LSP: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+}
+
+function enqueueLspUpdate(operation: () => Promise<void>): Promise<void> {
+    const update = lspUpdateQueue.then(operation);
+
+    lspUpdateQueue = update.catch(() => undefined);
+
+    return update;
+}
+
+async function performLspUpdateCheck(
+    context: vscode.ExtensionContext,
+): Promise<void> {
+    let result: LspBinaryUpdateResult;
+
+    try {
+        result = await updateLspBinary(context);
+    } catch (error) {
+        console.error("Failed to check for a Laravel LSP update:", error);
+        return;
+    }
+
+    if (result.status !== "updated") {
+        return;
+    }
+
+    try {
+        const restartedClient = await restartLspClient();
+
+        if (!restartedClient) {
+            throw new Error("The updated Laravel LSP did not start");
+        }
+    } catch (error) {
+        console.error("Failed to start the updated Laravel LSP:", error);
+
+        try {
+            await rollbackLspBinaryUpdate(context, result);
+            await restartLspClient();
+        } catch (rollbackError) {
+            console.error(
+                "Failed to restore the previous Laravel LSP:",
+                rollbackError,
+            );
+        }
+
+        return;
+    }
+
+    try {
+        await completeLspBinaryUpdate(context, result);
+    } catch (error) {
+        console.error("Failed to clean up old Laravel LSP binaries:", error);
+    }
+}

--- a/src/test/lsp-binary-update.test.ts
+++ b/src/test/lsp-binary-update.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+    findCachedLspBinary,
+    findLspReleaseAsset,
+    LSP_UPDATE_THROTTLE_MS,
+    shouldCheckForLspUpdate,
+} from "../lsp/binary";
+
+const assets = [
+    {
+        name: "server-v1.2.3-arm64-darwin",
+        browser_download_url: "https://example.com/darwin-arm64",
+    },
+    {
+        name: "server-v1.2.3-x64-darwin",
+        browser_download_url: "https://example.com/darwin-x64",
+    },
+    {
+        name: "server-v1.2.3-arm64-linux",
+        browser_download_url: "https://example.com/linux-arm64",
+    },
+    {
+        name: "server-v1.2.3-x64-linux",
+        browser_download_url: "https://example.com/linux-x64",
+    },
+    {
+        name: "server-v1.2.3-x64-win32.exe",
+        browser_download_url: "https://example.com/windows-x64",
+    },
+];
+
+suite("Laravel LSP Binary Update Test Suite", () => {
+    test("selects the release asset for each supported platform", () => {
+        assert.strictEqual(
+            findLspReleaseAsset(assets, "darwin", "arm64")?.name,
+            "server-v1.2.3-arm64-darwin",
+        );
+        assert.strictEqual(
+            findLspReleaseAsset(assets, "darwin", "x64")?.name,
+            "server-v1.2.3-x64-darwin",
+        );
+        assert.strictEqual(
+            findLspReleaseAsset(assets, "linux", "arm64")?.name,
+            "server-v1.2.3-arm64-linux",
+        );
+        assert.strictEqual(
+            findLspReleaseAsset(assets, "linux", "x64")?.name,
+            "server-v1.2.3-x64-linux",
+        );
+        assert.strictEqual(
+            findLspReleaseAsset(assets, "win32", "x64")?.name,
+            "server-v1.2.3-x64-win32.exe",
+        );
+        assert.strictEqual(
+            findLspReleaseAsset(assets, "win32", "arm64"),
+            undefined,
+        );
+    });
+
+    test("throttles update checks for two hours", () => {
+        const now = 10_000_000;
+
+        assert.strictEqual(shouldCheckForLspUpdate(undefined, now), true);
+        assert.strictEqual(shouldCheckForLspUpdate(now, now), false);
+        assert.strictEqual(
+            shouldCheckForLspUpdate(now - LSP_UPDATE_THROTTLE_MS + 1, now),
+            false,
+        );
+        assert.strictEqual(
+            shouldCheckForLspUpdate(now - LSP_UPDATE_THROTTLE_MS, now),
+            true,
+        );
+    });
+
+    test("uses the newest compatible cached binary", () => {
+        const root = path.join(path.parse(process.cwd()).root, "downloads");
+        const files = [
+            vscode.Uri.file(path.join(root, "server-v1.2.9-arm64-darwin")),
+            vscode.Uri.file(path.join(root, "server-v1.2.10-arm64-darwin")),
+            vscode.Uri.file(path.join(root, "server-v9.0.0-x64-darwin")),
+            vscode.Uri.file(
+                path.join(root, "server-v9.0.0-arm64-darwin.pending"),
+            ),
+        ];
+
+        assert.strictEqual(
+            path.basename(
+                findCachedLspBinary(files, "darwin", "arm64")!.fsPath,
+            ),
+            "server-v1.2.10-arm64-darwin",
+        );
+    });
+});


### PR DESCRIPTION
Automatically keep the bundled Laravel LSP binary up to date without requiring an extension release for every LSP release.

### How it works

- On activation, start with the latest compatible cached LSP binary.
- If an update check has not run within two hours, fetch the latest Laravel LSP release metadata.
- If the matching binary is already cached, continue using it.
- Otherwise, download the binary, restart the LSP, and remove the previous version.
- Restore the previous binary if the updated LSP fails to start.
- Allow users to bypass the throttle and re-download the latest binary with the `Laravel: Update LSP command`.

### Development

- Skip managed updates when `LARAVEL_LSP_BINARY_PATH` is configured.