### PR TITLE
Fix nested translations on Windows not recognized

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -337,6 +337,7 @@ $translator = new class
             ->after($path.DIRECTORY_SEPARATOR)
             ->after(DIRECTORY_SEPARATOR)
             ->replaceLast('.php', '')
+            ->replace(DIRECTORY_SEPARATOR, '/')
             ->value();
 
         if ($namespace) {

--- a/src/templates/translations.ts
+++ b/src/templates/translations.ts
@@ -337,6 +337,7 @@ $translator = new class
             ->after($path.DIRECTORY_SEPARATOR)
             ->after(DIRECTORY_SEPARATOR)
             ->replaceLast('.php', '')
+            ->replace(DIRECTORY_SEPARATOR, '/')
             ->value();
 
         if ($namespace) {


### PR DESCRIPTION
## Problem
Nested translation keys e.g. `__('app/test.label')` are displayed as "not found" on Windows, even though the translation exists. This is caused by the translation resolution logic not normalizing Windows (`\`) and Unix (`/`) path separators when handling nested keys.

## Fix
Normalize file paths to use forward slashes consistently across all platforms during translation key resolution.

