### PR TITLE
Fixed env() diagnostic false positive when default value is provided.…

### DIFF
--- a/src/features/env.ts
+++ b/src/features/env.ts
@@ -80,8 +80,12 @@ export const diagnosticProvider = (
         doc,
         toFind,
         getEnv,
-        ({ param, index }) => {
+        ({ param, index, item }) => {
             if (index > 0) {
+                return null;
+            }
+
+            if ("arguments" in item && item.arguments.children.length > 1) {
                 return null;
             }
 


### PR DESCRIPTION
Fixes #668

skip the missing environment diagnostic when env() is called with a default value.