### PR TITLE
LSP Support for multi root workspaces

### DIFF
--- a/src/artisan/commands/FactoryMakeCommand.ts
+++ b/src/artisan/commands/FactoryMakeCommand.ts
@@ -1,5 +1,5 @@
-import { Command } from "../types";
 import { getModelClassnames } from "@src/lsp/models";
+import { Command } from "../types";
 
 export const FactoryMakeCommand: Command = {
     name: "make:factory",

--- a/src/artisan/commands/ObserverMakeCommand.ts
+++ b/src/artisan/commands/ObserverMakeCommand.ts
@@ -1,5 +1,5 @@
-import { Command } from "../types";
 import { getModelClassnames } from "@src/lsp/models";
+import { Command } from "../types";
 
 export const ObserverMakeCommand: Command = {
     name: "make:observer",

--- a/src/commands/artisan.ts
+++ b/src/commands/artisan.ts
@@ -1,10 +1,10 @@
 import * as vscode from "vscode";
 
-import { Command } from "@src/artisan/types";
 import { buildArtisanCommand } from "@src/artisan/builder";
+import { Command } from "@src/artisan/types";
 import { getPathFromOutput } from "@src/support/artisan";
 import { artisan, runArtisanInTerminal } from "@src/support/php";
-import { getWorkspaceFolders } from "@src/support/project";
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { openFileCommand } from ".";
 
 export const runArtisanCommand = async (
@@ -23,7 +23,7 @@ export const runArtisanCommand = async (
         }
     }
 
-    const workspaceFolder = getWorkspaceFolder(uri);
+    const workspaceFolder = getProjectWorkspaceFolder(uri);
 
     if (!workspaceFolder) {
         vscode.window.showErrorMessage("Cannot detect active workspace");
@@ -101,28 +101,4 @@ const openGeneratedFile = (
     }
 
     openFileCommand(vscode.Uri.file(outputPath), 1, 1);
-};
-
-const getWorkspaceFolder = (
-    uri: vscode.Uri | undefined,
-): vscode.WorkspaceFolder | undefined => {
-    if (uri) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-
-        if (workspaceFolder) {
-            return workspaceFolder;
-        }
-    }
-
-    if (vscode.window.activeTextEditor) {
-        const fileUri = vscode.window.activeTextEditor.document.uri;
-
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
-
-        if (workspaceFolder) {
-            return workspaceFolder;
-        }
-    }
-
-    return getWorkspaceFolders()?.[0];
 };

--- a/src/commands/goToRoute.ts
+++ b/src/commands/goToRoute.ts
@@ -1,8 +1,12 @@
 import { getRoutes, type RouteItem } from "@src/lsp/routes";
 import { getViews, type ViewItem } from "@src/lsp/views";
-import { projectPath } from "@src/support/project";
+import { getLaravelWorkspaceFolders, projectPath } from "@src/support/project";
 import * as vscode from "vscode";
 import { commandName } from ".";
+
+type WorkspaceQuickPickItem = vscode.QuickPickItem & {
+    workspaceFolder: vscode.WorkspaceFolder;
+};
 
 type RouteQuickPickItem = vscode.QuickPickItem & {
     route: RouteItem;
@@ -17,7 +21,9 @@ type RouteTarget = {
 const unnamedRouteLabel = "(unnamed)";
 
 export const goToRouteCommand = async () => {
-    const routes = await loadRoutes();
+    const selectedWorkspaceFolder = await selectWorkspaceFolder();
+
+    const routes = await loadRoutes(selectedWorkspaceFolder?.workspaceFolder);
 
     if (routes.length === 0) {
         vscode.window.showWarningMessage("No Laravel routes found.");
@@ -39,8 +45,14 @@ export const goToRouteCommand = async () => {
     }
 
     const target =
-        (await resolveLivewireRouteTarget(selected.route)) ??
-        (await resolveRouteTarget(selected.route));
+        (await resolveLivewireRouteTarget(
+            selected.route,
+            selectedWorkspaceFolder?.workspaceFolder,
+        )) ??
+        (await resolveRouteTarget(
+            selected.route,
+            selectedWorkspaceFolder?.workspaceFolder,
+        ));
 
     if (!target) {
         vscode.window.showWarningMessage(
@@ -57,9 +69,37 @@ export const goToRouteCommand = async () => {
     );
 };
 
+const selectWorkspaceFolder = async (): Promise<
+    WorkspaceQuickPickItem | undefined
+> => {
+    const workspaceFolders = getLaravelWorkspaceFolders();
+
+    if (workspaceFolders.length === 0) {
+        return undefined;
+    }
+
+    return await vscode.window.showQuickPick(
+        buildWorkspaceFolderQuickPickItems(workspaceFolders),
+        {
+            title: "Laravel: Go to Route",
+            matchOnDescription: false,
+            matchOnDetail: false,
+            placeHolder: "Select a workspace folder to load routes from",
+        },
+    );
+};
+
 export const formatRouteLabel = (route: RouteItem): string => {
     return `${route.method} ${route.uri} | ${route.name || unnamedRouteLabel}`;
 };
+
+const buildWorkspaceFolderQuickPickItems = (
+    workspaceFolders: vscode.WorkspaceFolder[],
+): WorkspaceQuickPickItem[] =>
+    workspaceFolders.map((workspaceFolder) => ({
+        label: workspaceFolder.name,
+        workspaceFolder,
+    }));
 
 export const buildRouteQuickPickItems = (
     routes: RouteItem[],
@@ -76,23 +116,28 @@ export const buildRouteQuickPickItems = (
         }));
 };
 
-const loadRoutes = async (): Promise<RouteItem[]> => {
-    return await getRoutes();
+const loadRoutes = async (
+    workspaceFolder?: vscode.WorkspaceFolder,
+): Promise<RouteItem[]> => {
+    return await getRoutes(workspaceFolder);
 };
 
-const loadViews = async (): Promise<ViewItem[]> => {
-    return await getViews();
+const loadViews = async (
+    workspaceFolder?: vscode.WorkspaceFolder,
+): Promise<ViewItem[]> => {
+    return await getViews(workspaceFolder);
 };
 
 const resolveRouteTarget = async (
     route: RouteItem,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): Promise<RouteTarget | null> => {
     if (!route.filename) {
         return null;
     }
 
     return {
-        uri: vscode.Uri.file(projectPath(route.filename)),
+        uri: vscode.Uri.file(projectPath(route.filename, workspaceFolder)),
         line: Math.max((route.line ?? 1) - 1, 0),
         position: 0,
     };
@@ -100,12 +145,13 @@ const resolveRouteTarget = async (
 
 const resolveLivewireRouteTarget = async (
     route: RouteItem,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): Promise<RouteTarget | null> => {
     if (!route.livewire) {
         return null;
     }
 
-    const view = (await loadViews()).find(
+    const view = (await loadViews(workspaceFolder)).find(
         (item) => item.key === route.livewire,
     );
 
@@ -114,7 +160,7 @@ const resolveLivewireRouteTarget = async (
     }
 
     return {
-        uri: vscode.Uri.file(projectPath(view.path)),
+        uri: vscode.Uri.file(projectPath(view.path, workspaceFolder)),
         line: 0,
         position: 0,
     };

--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -13,6 +13,7 @@ import { commandName } from ".";
 import { config } from "../support/config";
 import { showErrorPopup } from "../support/popup";
 import {
+    getProjectWorkspaceFolder,
     getWorkspaceFolders,
     projectPath,
     projectPathExists,
@@ -153,7 +154,7 @@ export const runPintOnSave = (document: vscode.TextDocument) => {
 
     if (
         !document.uri.fsPath.startsWith(
-            getWorkspaceFolders()[0]?.uri?.fsPath || "",
+            getProjectWorkspaceFolder()?.uri?.fsPath || "",
         )
     ) {
         return;

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,5 +1,5 @@
 import { LanguageClient } from "vscode-languageclient/node";
-import { getProjectWorkspaceFolder } from "../support/project";
+import { getFirstLaravelWorkspaceFolder } from "../support/project";
 import { getLspBinaryPath } from "./binary";
 import { createClientOptions, createServerOptions } from "./options";
 import { clearResolvedPhpCommand, setResolvedPhpCommand } from "./php";
@@ -23,7 +23,7 @@ export async function startLspClient(): Promise<LanguageClient | undefined> {
         return undefined;
     }
 
-    const workspaceFolder = getProjectWorkspaceFolder();
+    const workspaceFolder = getFirstLaravelWorkspaceFolder();
     const serverOptions = createServerOptions(binaryPath, workspaceFolder);
     const clientOptions = createClientOptions();
 

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -25,7 +25,7 @@ export async function startLspClient(): Promise<LanguageClient | undefined> {
 
     const workspaceFolder = getProjectWorkspaceFolder();
     const serverOptions = createServerOptions(binaryPath, workspaceFolder);
-    const clientOptions = createClientOptions(workspaceFolder);
+    const clientOptions = createClientOptions();
 
     const lspClient = new LanguageClient(
         "laravelLsp",

--- a/src/lsp/models.ts
+++ b/src/lsp/models.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 interface ModelItem {
@@ -6,15 +9,22 @@ interface ModelItem {
 
 type Models = Record<string, ModelItem>;
 
-export const getModels = (): Promise<Models> => {
+export const getModels = (
+    workspaceFolder: vscode.WorkspaceFolder,
+): Promise<Models> => {
     return sendLspRequest<Models>("laravel/data", {
         name: "models",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };
 
-export const getModelClassnames = async (): Promise<Record<string, string>> => {
+export const getModelClassnames = async (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<Record<string, string>> => {
     return Object.fromEntries(
-        Object.values(await getModels()).map((model) => [
+        Object.values(await getModels(workspaceFolder)).map((model) => [
             model.class,
             model.class,
         ]),

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -29,6 +29,7 @@ export function createClientOptions(
     workspaceFolder?: vscode.WorkspaceFolder,
 ): LanguageClientOptions {
     return {
+        workspaceFolder,
         documentSelector: [
             { scheme: "file", language: "php" },
             { scheme: "file", language: "blade" },

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -29,7 +29,6 @@ export function createClientOptions(
     workspaceFolder?: vscode.WorkspaceFolder,
 ): LanguageClientOptions {
     return {
-        workspaceFolder,
         documentSelector: [
             { scheme: "file", language: "php" },
             { scheme: "file", language: "blade" },

--- a/src/lsp/paths.ts
+++ b/src/lsp/paths.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface PathItem {
@@ -5,8 +8,13 @@ export interface PathItem {
     path: string;
 }
 
-export const getPaths = (): Promise<PathItem[]> => {
+export const getPaths = (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<PathItem[]> => {
     return sendLspRequest<PathItem[]>("laravel/data", {
         name: "paths",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };

--- a/src/lsp/routes.ts
+++ b/src/lsp/routes.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface RouteItem {
@@ -11,8 +14,13 @@ export interface RouteItem {
     livewire: string | null;
 }
 
-export const getRoutes = (): Promise<RouteItem[]> => {
+export const getRoutes = (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<RouteItem[]> => {
     return sendLspRequest<RouteItem[]>("laravel/data", {
         name: "routes",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };

--- a/src/lsp/views.ts
+++ b/src/lsp/views.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface ViewItem {
@@ -15,8 +18,13 @@ export interface ViewItem {
     };
 }
 
-export const getViews = (): Promise<ViewItem[]> => {
+export const getViews = (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<ViewItem[]> => {
     return sendLspRequest<ViewItem[]>("laravel/data", {
         name: "views",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -1,6 +1,11 @@
 import { readdirSync } from "fs";
 import * as vscode from "vscode";
-import { getWorkspaceFolders, hasWorkspace } from "./project";
+import {
+    getFirstLaravelWorkspaceFolder,
+    getLaravelWorkspaceFolders,
+    getProjectWorkspaceFolder,
+    getWorkspaceFolders,
+} from "./project";
 import { debounce, leadingDebounce } from "./util";
 
 export type FileEvent = "change" | "create" | "delete";
@@ -10,37 +15,43 @@ let watchers: vscode.FileSystemWatcher[] = [];
 export type WatcherPattern =
     | string
     | string[]
-    | (() => Promise<string | string[] | null>);
+    | ((
+          workspaceFolder: vscode.WorkspaceFolder,
+      ) => Promise<string | string[] | null>);
 
 export const defaultFileEvents: FileEvent[] = ["change", "create", "delete"];
 
 export const loadAndWatch = (
-    load: () => void,
+    load: (workspaceFolder: vscode.WorkspaceFolder) => void,
     patterns: WatcherPattern,
     events: FileEvent[] = defaultFileEvents,
+    workspaceFolder: vscode.WorkspaceFolder,
     reloadOnComposerChanges: boolean = true,
 ): void => {
-    if (!hasWorkspace()) {
-        return;
-    }
+    load(workspaceFolder);
 
-    load();
-
-    const loadFunc = leadingDebounce(load, 1000);
+    const loadFunc = leadingDebounce(() => load(workspaceFolder), 1000);
 
     if (patterns instanceof Function) {
-        patterns().then((result) => {
+        patterns(workspaceFolder).then((result) => {
             if (result !== null) {
                 createFileWatcher(
                     result,
                     loadFunc,
                     events,
+                    workspaceFolder,
                     reloadOnComposerChanges,
                 );
             }
         });
     } else {
-        createFileWatcher(patterns, loadFunc, events, reloadOnComposerChanges);
+        createFileWatcher(
+            patterns,
+            loadFunc,
+            events,
+            workspaceFolder,
+            reloadOnComposerChanges,
+        );
     }
 };
 
@@ -51,7 +62,7 @@ const ignoreDirs = ["node_modules", ".git", "vendor", "storage"];
 export const inAppDirs = (pattern: string) => {
     if (!appDirsRead) {
         appDirsRead = true;
-        readdirSync(getWorkspaceFolders()[0].uri.fsPath, {
+        readdirSync(getProjectWorkspaceFolder()!.uri.fsPath, {
             withFileTypes: true,
         }).forEach((file) => {
             if (file.isDirectory() && !ignoreDirs.includes(file.name)) {
@@ -92,41 +103,48 @@ export const watchForComposerChanges = () => {
         }
     }, 1000);
 
-    const watcher = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(
-            getWorkspaceFolders()[0],
-            "vendor/composer/autoload_*.php",
-        ),
-    );
+    getLaravelWorkspaceFolders().forEach((workspaceFolder) => {
+        const watcher = vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(
+                workspaceFolder,
+                "vendor/composer/autoload_*.php",
+            ),
+        );
 
-    watcher.onDidChange(onChange);
-    watcher.onDidCreate(onChange);
-    watcher.onDidDelete(onChange);
+        watcher.onDidChange(onChange);
+        watcher.onDidCreate(onChange);
+        watcher.onDidDelete(onChange);
 
-    registerWatcher(watcher);
+        registerWatcher(watcher);
+    });
 };
 
 export const createFileWatcher = (
     patterns: string | string[],
     callback: (e: vscode.Uri) => void,
     events: FileEvent[] = defaultFileEvents,
+    workspaceFolder:
+        | vscode.WorkspaceFolder
+        | undefined = getFirstLaravelWorkspaceFolder(),
     reloadOnComposerChanges: boolean = true,
 ): vscode.FileSystemWatcher[] => {
-    if (!hasWorkspace()) {
+    if (!workspaceFolder) {
         return [];
     }
 
     patterns = typeof patterns === "string" ? [patterns] : patterns;
 
     return patterns.map((pattern) => {
-        if (patternWatchers[pattern]) {
-            patternWatchers[pattern].callbacks.push({
+        const key = [workspaceFolder.name, pattern].join(":");
+
+        if (patternWatchers[key]) {
+            patternWatchers[key].callbacks.push({
                 callback,
                 events,
                 reloadOnComposerChanges,
             });
 
-            return patternWatchers[pattern].watcher;
+            return patternWatchers[key].watcher;
         }
 
         const watcher = vscode.workspace.createFileSystemWatcher(
@@ -134,7 +152,7 @@ export const createFileWatcher = (
         );
 
         watcher.onDidChange((...args) => {
-            patternWatchers[pattern].callbacks.forEach((cb) => {
+            patternWatchers[key].callbacks.forEach((cb) => {
                 if (cb.events.includes("change")) {
                     cb.callback(...args);
                 }
@@ -142,7 +160,7 @@ export const createFileWatcher = (
         });
 
         watcher.onDidCreate((...args) => {
-            patternWatchers[pattern].callbacks.forEach((cb) => {
+            patternWatchers[key].callbacks.forEach((cb) => {
                 if (cb.events.includes("create")) {
                     cb.callback(...args);
                 }
@@ -150,14 +168,14 @@ export const createFileWatcher = (
         });
 
         watcher.onDidDelete((...args) => {
-            patternWatchers[pattern].callbacks.forEach((cb) => {
+            patternWatchers[key].callbacks.forEach((cb) => {
                 if (cb.events.includes("delete")) {
                     cb.callback(...args);
                 }
             });
         });
 
-        patternWatchers[pattern] = {
+        patternWatchers[key] = {
             watcher,
             callbacks: [{ callback, events, reloadOnComposerChanges }],
         };

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -4,7 +4,6 @@ import {
     getFirstLaravelWorkspaceFolder,
     getLaravelWorkspaceFolders,
     getProjectWorkspaceFolder,
-    getWorkspaceFolders,
 } from "./project";
 import { debounce, leadingDebounce } from "./util";
 
@@ -148,7 +147,7 @@ export const createFileWatcher = (
         }
 
         const watcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(getWorkspaceFolders()[0], pattern),
+            new vscode.RelativePattern(workspaceFolder, pattern),
         );
 
         watcher.onDidChange((...args) => {

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -42,36 +42,64 @@ export const resolveWorkspaceProjectFolder = (
     };
 };
 
-export const getProjectWorkspaceFolder = ():
-    | vscode.WorkspaceFolder
-    | undefined => {
-    const workspaceFolder = getWorkspaceFolders()[0];
+export const getProjectWorkspaceFolder = (
+    uri?: vscode.Uri | undefined,
+): vscode.WorkspaceFolder | undefined => {
+    // Case when we know the file URI and we want to get the VSCode workspace folder for it.
+    // Useful for Laravel artisan commands in the VSCode file explorer
+    if (uri) {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
 
-    if (!workspaceFolder) {
-        return undefined;
+        if (workspaceFolder) {
+            return workspaceFolder;
+        }
     }
 
-    return resolveWorkspaceProjectFolder(workspaceFolder);
+    // Case when we don't know the file URI but we have an active text editor,
+    // so we try to get the workspace folder from it
+    if (vscode.window.activeTextEditor) {
+        const fileUri = vscode.window.activeTextEditor.document.uri;
+
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
+
+        if (workspaceFolder) {
+            return workspaceFolder;
+        }
+    }
+
+    // Fallback, just return the first workspace folder if it exists
+    return getFirstLaravelWorkspaceFolder();
 };
 
-export const projectPath = (srcPath = ""): string => {
+export const getWorkspaceFolders = (): readonly vscode.WorkspaceFolder[] =>
+    vscode.workspace.workspaceFolders || [];
+
+export const getLaravelWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
+    return getWorkspaceFolders().filter((workspaceFolder) =>
+        fs.existsSync(
+            path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
+        ),
+    )!;
+};
+
+export const getFirstLaravelWorkspaceFolder = ():
+    | vscode.WorkspaceFolder
+    | undefined => getLaravelWorkspaceFolders()?.[0];
+
+export const hasWorkspace = (): boolean => {
+    return (
+        getWorkspaceFolders() instanceof Array &&
+        getWorkspaceFolders().length > 0
+    );
+};
+
+export const projectPath = (
+    srcPath = "",
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): string => {
     srcPath = basePath(srcPath);
 
-    for (let workspaceFolder of getWorkspaceFolders()) {
-        if (
-            fs.existsSync(
-                path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
-            )
-        ) {
-            return path.join(workspaceFolder.uri.fsPath, srcPath);
-        }
-
-        if (fs.existsSync(path.join(workspaceFolder.uri.fsPath, srcPath))) {
-            return path.join(workspaceFolder.uri.fsPath, srcPath);
-        }
-    }
-
-    return "";
+    return path.join(workspaceFolder.uri.fsPath, srcPath);
 };
 
 export const relativePath = (srcPath: string): string => {
@@ -89,20 +117,16 @@ export const relativePath = (srcPath: string): string => {
     return srcPath;
 };
 
-export const hasWorkspace = (): boolean => {
-    return (
-        vscode.workspace.workspaceFolders instanceof Array &&
-        vscode.workspace.workspaceFolders.length > 0
-    );
+export const projectPathExists = (
+    path: string,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): boolean => {
+    return fs.existsSync(projectPath(path, workspaceFolder));
 };
 
-export const getWorkspaceFolders = () =>
-    vscode.workspace.workspaceFolders || [];
-
-export const projectPathExists = (path: string): boolean => {
-    return fs.existsSync(projectPath(path));
-};
-
-export const readFileInProject = (path: string): string => {
-    return fs.readFileSync(projectPath(path), "utf8");
+export const readFileInProject = (
+    path: string,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): string => {
+    return fs.readFileSync(projectPath(path, workspaceFolder), "utf8");
 };

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -120,7 +120,7 @@ export const waitForValue = <T>(
                 return resolve(value());
             }
 
-            if (value() === null) {
+            if (!value()) {
                 return setTimeout(checkForValue, 100);
             }
 

--- a/src/test-runner/explorer.ts
+++ b/src/test-runner/explorer.ts
@@ -17,21 +17,32 @@ export interface TestSuite {
     }[];
 }
 
-export const updateExplorer = async (controller: vscode.TestController) => {
-    const suites = await getTestSuites();
+export const updateExplorer = async (
+    controller: vscode.TestController,
+    workspaceFolder: vscode.WorkspaceFolder,
+) => {
+    const suites = await getTestSuites(workspaceFolder);
 
     controller.items.replace(
-        suites.map((suite) => buildSuiteItem(controller, suite)),
+        suites.map((suite) =>
+            buildSuiteItem(controller, suite, workspaceFolder),
+        ),
     );
 };
 
-const getTestSuites = () => {
-    return sendLspRequest<TestSuite[]>("laravel/data", { name: "tests" });
+const getTestSuites = (workspaceFolder: vscode.WorkspaceFolder) => {
+    return sendLspRequest<TestSuite[]>("laravel/data", {
+        name: "tests",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
+    });
 };
 
 const buildSuiteItem = (
     controller: vscode.TestController,
     suite: TestSuite,
+    workspaceFolder: vscode.WorkspaceFolder,
 ) => {
     const suiteItem = controller.createTestItem(
         `suite:${suite.name}`,
@@ -40,7 +51,7 @@ const buildSuiteItem = (
     );
 
     suite.files.forEach((file) => {
-        const uri = vscode.Uri.file(projectPath(file.path));
+        const uri = vscode.Uri.file(projectPath(file.path, workspaceFolder));
         const basePath = getBasePath(file.path, file.directories);
 
         const parent = ensureFolderPath(

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -2,37 +2,42 @@ import * as vscode from "vscode";
 
 import { config } from "@src/support/config";
 import { loadAndWatch } from "@src/support/fileWatcher";
+import { getLaravelWorkspaceFolders } from "@src/support/project";
 import { updateExplorer } from "./explorer";
 import { runHandler } from "./runner";
 
-export const registerTestRunner = () => {
+export const registerTestRunner = async () => {
     if (!config("testRunner.enabled", true)) {
         return;
     }
 
-    const controller = vscode.tests.createTestController(
-        "laravel-tests",
-        "Laravel Tests",
-    );
+    for (const workspaceFolder of getLaravelWorkspaceFolders()) {
+        const controller = vscode.tests.createTestController(
+            `${workspaceFolder.name}-tests`,
+            `${workspaceFolder.name} Tests`,
+        );
 
-    controller.createRunProfile(
-        "Run Tests",
-        vscode.TestRunProfileKind.Run,
-        (request, token) => runHandler(controller, request, token),
-        true,
-    );
+        controller.createRunProfile(
+            "Run Tests",
+            vscode.TestRunProfileKind.Run,
+            (request, token) =>
+                runHandler(controller, request, token, workspaceFolder),
+            true,
+        );
 
-    controller.resolveHandler = async (item) => {
-        if (!item) {
-            await updateExplorer(controller);
-        }
-    };
+        controller.resolveHandler = async (item) => {
+            if (!item) {
+                await updateExplorer(controller, workspaceFolder);
+            }
+        };
 
-    loadAndWatch(
-        () => {
-            void updateExplorer(controller);
-        },
-        ["tests/**/*"],
-        ["create", "delete", "change"],
-    );
+        loadAndWatch(
+            (workspaceFolder) => {
+                void updateExplorer(controller, workspaceFolder);
+            },
+            ["tests/**/*"],
+            ["create", "delete", "change"],
+            workspaceFolder,
+        );
+    }
 };

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -11,7 +11,7 @@ export const registerTestRunner = async () => {
         return;
     }
 
-    for (const workspaceFolder of getLaravelWorkspaceFolders()) {
+    getLaravelWorkspaceFolders().forEach((workspaceFolder) => {
         const controller = vscode.tests.createTestController(
             `${workspaceFolder.name}-tests`,
             `${workspaceFolder.name} Tests`,
@@ -39,5 +39,5 @@ export const registerTestRunner = async () => {
             ["create", "delete", "change"],
             workspaceFolder,
         );
-    }
+    });
 };

--- a/src/test-runner/runner.ts
+++ b/src/test-runner/runner.ts
@@ -1,27 +1,32 @@
-import * as vscode from "vscode";
 import { spawn } from "child_process";
+import * as vscode from "vscode";
 
+import { getPaths, type PathItem } from "@src/lsp/paths";
 import { getPhpCommand } from "@src/lsp/php";
 import { projectPath } from "@src/support/project";
-import { getPaths, type PathItem } from "@src/lsp/paths";
-import { parseLine, buildErrorMessage, TeamcityEvent } from "./teamcity";
+import { buildErrorMessage, parseLine, TeamcityEvent } from "./teamcity";
 
 export const runHandler = async (
     controller: vscode.TestController,
     request: vscode.TestRunRequest,
     token: vscode.CancellationToken,
+    workspaceFolder: vscode.WorkspaceFolder,
 ) => {
     const run = controller.createTestRun(request);
-    const paths = await getPaths();
+    const paths = await getPaths(workspaceFolder);
 
     if (!request.include) {
         const testMap = buildTestMapFromController(controller);
         testMap.forEach((test) => run.enqueued(test));
-        await executeTests([], testMap, run, token, paths);
+        await executeTests([], testMap, run, token, paths, workspaceFolder);
     } else {
         for (const item of request.include) {
-            if (token.isCancellationRequested) break;
-            if (request.exclude?.includes(item)) continue;
+            if (token.isCancellationRequested) {
+                break;
+            }
+            if (request.exclude?.includes(item)) {
+                continue;
+            }
 
             const testMap = buildTestMap(item, request.exclude);
             testMap.forEach((test) => run.enqueued(test));
@@ -31,6 +36,7 @@ export const runHandler = async (
                 run,
                 token,
                 paths,
+                workspaceFolder,
             );
         }
     }
@@ -41,9 +47,15 @@ export const runHandler = async (
 type ItemType = "suite" | "directory" | "file" | "test";
 
 const getItemType = (item: vscode.TestItem): ItemType => {
-    if (item.id.startsWith("suite:")) return "suite";
-    if (item.id.startsWith("dir:")) return "directory";
-    if (item.id.startsWith("file:")) return "file";
+    if (item.id.startsWith("suite:")) {
+        return "suite";
+    }
+    if (item.id.startsWith("dir:")) {
+        return "directory";
+    }
+    if (item.id.startsWith("file:")) {
+        return "file";
+    }
     return "test";
 };
 
@@ -74,7 +86,9 @@ const buildTestMap = (
     const map = new Map<string, vscode.TestItem>();
 
     const collect = (current: vscode.TestItem) => {
-        if (exclude?.includes(current)) return;
+        if (exclude?.includes(current)) {
+            return;
+        }
 
         if (current.children.size === 0) {
             const eventName = getEventName(current);
@@ -117,6 +131,7 @@ const executeTests = async (
     run: vscode.TestRun,
     token: vscode.CancellationToken,
     paths: PathItem[],
+    workspaceFolder: vscode.WorkspaceFolder,
 ): Promise<void> => {
     return new Promise((resolve) => {
         const [executable, ...commandArgs] = [
@@ -129,7 +144,7 @@ const executeTests = async (
         ];
 
         const proc = spawn(executable, commandArgs, {
-            cwd: projectPath(),
+            cwd: projectPath("", workspaceFolder),
             detached: true,
             env: getProcessEnv(),
         });
@@ -194,7 +209,9 @@ const handleEvent = (
 ): void => {
     const test = testMap.get(event.attributes.name);
 
-    if (!test) return;
+    if (!test) {
+        return;
+    }
 
     switch (event.type) {
         case "testStarted":


### PR DESCRIPTION
This PR adds support for multi-root workspaces in the LSP version, similar to my previous PR for native VS Code support: https://github.com/laravel/vs-code-extension/pull/624.

As previously, I tried to modify the code as little as possible. Every method that uses a workspace now has a new workspaceFolder parameter. If a method can use the `workspaceFolder` from `vscode.window.activeTextEditor`, the parameter defaults to `getProjectWorkspaceFolder`.

I added an additional `vscode.window.showQuickPick` for selecting `workspace` in the `goToRouteCommand`.

I have only tested this in VS Code on Linux, so any feedback would be greatly appreciated.

Depends on server part https://github.com/laravel/lsp/pull/66