### PR TITLE
LSP - support for multi root workspaces (separate LSP processes approach)

### DIFF
--- a/src/artisan/commands/FactoryMakeCommand.ts
+++ b/src/artisan/commands/FactoryMakeCommand.ts
@@ -1,5 +1,5 @@
-import { Command } from "../types";
 import { getModelClassnames } from "@src/lsp/models";
+import { Command } from "../types";
 
 export const FactoryMakeCommand: Command = {
     name: "make:factory",

--- a/src/artisan/commands/ObserverMakeCommand.ts
+++ b/src/artisan/commands/ObserverMakeCommand.ts
@@ -1,5 +1,5 @@
-import { Command } from "../types";
 import { getModelClassnames } from "@src/lsp/models";
+import { Command } from "../types";
 
 export const ObserverMakeCommand: Command = {
     name: "make:observer",

--- a/src/commands/artisan.ts
+++ b/src/commands/artisan.ts
@@ -4,7 +4,10 @@ import { buildArtisanCommand } from "@src/artisan/builder";
 import { Command } from "@src/artisan/types";
 import { getPathFromOutput } from "@src/support/artisan";
 import { artisan, runArtisanInTerminal } from "@src/support/php";
-import { getProjectWorkspaceFolder } from "@src/support/project";
+import {
+    getProjectWorkspaceFolder,
+    resolveWorkspaceProjectFolder,
+} from "@src/support/project";
 import { openFileCommand } from ".";
 
 export const runArtisanCommand = async (
@@ -23,7 +26,9 @@ export const runArtisanCommand = async (
         }
     }
 
-    const workspaceFolder = getProjectWorkspaceFolder(uri);
+    const workspaceFolder = resolveWorkspaceProjectFolder(
+        getProjectWorkspaceFolder(uri),
+    );
 
     if (!workspaceFolder) {
         vscode.window.showErrorMessage("Cannot detect active workspace");

--- a/src/commands/artisan.ts
+++ b/src/commands/artisan.ts
@@ -1,10 +1,10 @@
 import * as vscode from "vscode";
 
-import { Command } from "@src/artisan/types";
 import { buildArtisanCommand } from "@src/artisan/builder";
+import { Command } from "@src/artisan/types";
 import { getPathFromOutput } from "@src/support/artisan";
 import { artisan, runArtisanInTerminal } from "@src/support/php";
-import { getWorkspaceFolders } from "@src/support/project";
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { openFileCommand } from ".";
 
 export const runArtisanCommand = async (
@@ -23,7 +23,7 @@ export const runArtisanCommand = async (
         }
     }
 
-    const workspaceFolder = getWorkspaceFolder(uri);
+    const workspaceFolder = getProjectWorkspaceFolder(uri);
 
     if (!workspaceFolder) {
         vscode.window.showErrorMessage("Cannot detect active workspace");
@@ -101,28 +101,4 @@ const openGeneratedFile = (
     }
 
     openFileCommand(vscode.Uri.file(outputPath), 1, 1);
-};
-
-const getWorkspaceFolder = (
-    uri: vscode.Uri | undefined,
-): vscode.WorkspaceFolder | undefined => {
-    if (uri) {
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-
-        if (workspaceFolder) {
-            return workspaceFolder;
-        }
-    }
-
-    if (vscode.window.activeTextEditor) {
-        const fileUri = vscode.window.activeTextEditor.document.uri;
-
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
-
-        if (workspaceFolder) {
-            return workspaceFolder;
-        }
-    }
-
-    return getWorkspaceFolders()?.[0];
 };

--- a/src/commands/artisan.ts
+++ b/src/commands/artisan.ts
@@ -7,6 +7,7 @@ import { artisan, runArtisanInTerminal } from "@src/support/php";
 import {
     getProjectWorkspaceFolder,
     resolveWorkspaceProjectFolder,
+    selectWorkspaceFolder,
 } from "@src/support/project";
 import { openFileCommand } from ".";
 
@@ -26,9 +27,9 @@ export const runArtisanCommand = async (
         }
     }
 
-    const workspaceFolder = resolveWorkspaceProjectFolder(
-        getProjectWorkspaceFolder(uri),
-    );
+    const workspaceFolder = uri
+        ? resolveWorkspaceProjectFolder(getProjectWorkspaceFolder(uri))
+        : (await selectWorkspaceFolder())?.workspaceFolder;
 
     if (!workspaceFolder) {
         vscode.window.showErrorMessage("Cannot detect active workspace");

--- a/src/commands/goToRoute.ts
+++ b/src/commands/goToRoute.ts
@@ -1,8 +1,12 @@
 import { getRoutes, type RouteItem } from "@src/lsp/routes";
 import { getViews, type ViewItem } from "@src/lsp/views";
-import { projectPath } from "@src/support/project";
+import { getLaravelWorkspaceFolders, projectPath } from "@src/support/project";
 import * as vscode from "vscode";
 import { commandName } from ".";
+
+type WorkspaceQuickPickItem = vscode.QuickPickItem & {
+    workspaceFolder: vscode.WorkspaceFolder;
+};
 
 type RouteQuickPickItem = vscode.QuickPickItem & {
     route: RouteItem;
@@ -17,7 +21,9 @@ type RouteTarget = {
 const unnamedRouteLabel = "(unnamed)";
 
 export const goToRouteCommand = async () => {
-    const routes = await loadRoutes();
+    const selectedWorkspaceFolder = await selectWorkspaceFolder();
+
+    const routes = await loadRoutes(selectedWorkspaceFolder?.workspaceFolder);
 
     if (routes.length === 0) {
         vscode.window.showWarningMessage("No Laravel routes found.");
@@ -39,8 +45,14 @@ export const goToRouteCommand = async () => {
     }
 
     const target =
-        (await resolveLivewireRouteTarget(selected.route)) ??
-        (await resolveRouteTarget(selected.route));
+        (await resolveLivewireRouteTarget(
+            selected.route,
+            selectedWorkspaceFolder?.workspaceFolder,
+        )) ??
+        (await resolveRouteTarget(
+            selected.route,
+            selectedWorkspaceFolder?.workspaceFolder,
+        ));
 
     if (!target) {
         vscode.window.showWarningMessage(
@@ -57,9 +69,37 @@ export const goToRouteCommand = async () => {
     );
 };
 
+const selectWorkspaceFolder = async (): Promise<
+    WorkspaceQuickPickItem | undefined
+> => {
+    const workspaceFolders = getLaravelWorkspaceFolders();
+
+    if (workspaceFolders.length === 0) {
+        return undefined;
+    }
+
+    return await vscode.window.showQuickPick(
+        buildWorkspaceFolderQuickPickItems(workspaceFolders),
+        {
+            title: "Laravel: Go to Route",
+            matchOnDescription: false,
+            matchOnDetail: false,
+            placeHolder: "Select a workspace folder to load routes from",
+        },
+    );
+};
+
 export const formatRouteLabel = (route: RouteItem): string => {
     return `${route.method} ${route.uri} | ${route.name || unnamedRouteLabel}`;
 };
+
+const buildWorkspaceFolderQuickPickItems = (
+    workspaceFolders: vscode.WorkspaceFolder[],
+): WorkspaceQuickPickItem[] =>
+    workspaceFolders.map((workspaceFolder) => ({
+        label: workspaceFolder.name,
+        workspaceFolder,
+    }));
 
 export const buildRouteQuickPickItems = (
     routes: RouteItem[],
@@ -76,23 +116,28 @@ export const buildRouteQuickPickItems = (
         }));
 };
 
-const loadRoutes = async (): Promise<RouteItem[]> => {
-    return await getRoutes();
+const loadRoutes = async (
+    workspaceFolder?: vscode.WorkspaceFolder,
+): Promise<RouteItem[]> => {
+    return await getRoutes(workspaceFolder);
 };
 
-const loadViews = async (): Promise<ViewItem[]> => {
-    return await getViews();
+const loadViews = async (
+    workspaceFolder?: vscode.WorkspaceFolder,
+): Promise<ViewItem[]> => {
+    return await getViews(workspaceFolder);
 };
 
 const resolveRouteTarget = async (
     route: RouteItem,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): Promise<RouteTarget | null> => {
     if (!route.filename) {
         return null;
     }
 
     return {
-        uri: vscode.Uri.file(projectPath(route.filename)),
+        uri: vscode.Uri.file(projectPath(route.filename, workspaceFolder)),
         line: Math.max((route.line ?? 1) - 1, 0),
         position: 0,
     };
@@ -100,12 +145,13 @@ const resolveRouteTarget = async (
 
 const resolveLivewireRouteTarget = async (
     route: RouteItem,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): Promise<RouteTarget | null> => {
     if (!route.livewire) {
         return null;
     }
 
-    const view = (await loadViews()).find(
+    const view = (await loadViews(workspaceFolder)).find(
         (item) => item.key === route.livewire,
     );
 
@@ -114,7 +160,7 @@ const resolveLivewireRouteTarget = async (
     }
 
     return {
-        uri: vscode.Uri.file(projectPath(view.path)),
+        uri: vscode.Uri.file(projectPath(view.path, workspaceFolder)),
         line: 0,
         position: 0,
     };

--- a/src/commands/goToRoute.ts
+++ b/src/commands/goToRoute.ts
@@ -1,15 +1,8 @@
 import { getRoutes, type RouteItem } from "@src/lsp/routes";
 import { getViews, type ViewItem } from "@src/lsp/views";
-import {
-    projectPath,
-    resolveWorkspaceProjectFolders,
-} from "@src/support/project";
+import { projectPath, selectWorkspaceFolder } from "@src/support/project";
 import * as vscode from "vscode";
 import { commandName } from ".";
-
-type WorkspaceQuickPickItem = vscode.QuickPickItem & {
-    workspaceFolder: vscode.WorkspaceFolder;
-};
 
 type RouteQuickPickItem = vscode.QuickPickItem & {
     route: RouteItem;
@@ -24,9 +17,9 @@ type RouteTarget = {
 const unnamedRouteLabel = "(unnamed)";
 
 export const goToRouteCommand = async () => {
-    const selectedWorkspaceFolder = await selectWorkspaceFolder();
+    const workspaceFolder = (await selectWorkspaceFolder())?.workspaceFolder;
 
-    const routes = await loadRoutes(selectedWorkspaceFolder?.workspaceFolder);
+    const routes = await loadRoutes(workspaceFolder);
 
     if (routes.length === 0) {
         vscode.window.showWarningMessage("No Laravel routes found.");
@@ -48,14 +41,8 @@ export const goToRouteCommand = async () => {
     }
 
     const target =
-        (await resolveLivewireRouteTarget(
-            selected.route,
-            selectedWorkspaceFolder?.workspaceFolder,
-        )) ??
-        (await resolveRouteTarget(
-            selected.route,
-            selectedWorkspaceFolder?.workspaceFolder,
-        ));
+        (await resolveLivewireRouteTarget(selected.route, workspaceFolder)) ??
+        (await resolveRouteTarget(selected.route, workspaceFolder));
 
     if (!target) {
         vscode.window.showWarningMessage(
@@ -72,37 +59,9 @@ export const goToRouteCommand = async () => {
     );
 };
 
-const selectWorkspaceFolder = async (): Promise<
-    WorkspaceQuickPickItem | undefined
-> => {
-    const workspaceFolders = resolveWorkspaceProjectFolders();
-
-    if (workspaceFolders.length <= 1) {
-        return undefined;
-    }
-
-    return await vscode.window.showQuickPick(
-        buildWorkspaceFolderQuickPickItems(workspaceFolders),
-        {
-            title: "Laravel: Go to Route",
-            matchOnDescription: false,
-            matchOnDetail: false,
-            placeHolder: "Select a workspace folder to load routes from",
-        },
-    );
-};
-
 export const formatRouteLabel = (route: RouteItem): string => {
     return `${route.method} ${route.uri} | ${route.name || unnamedRouteLabel}`;
 };
-
-const buildWorkspaceFolderQuickPickItems = (
-    workspaceFolders: vscode.WorkspaceFolder[],
-): WorkspaceQuickPickItem[] =>
-    workspaceFolders.map((workspaceFolder) => ({
-        label: workspaceFolder.name,
-        workspaceFolder,
-    }));
 
 export const buildRouteQuickPickItems = (
     routes: RouteItem[],

--- a/src/commands/goToRoute.ts
+++ b/src/commands/goToRoute.ts
@@ -74,7 +74,7 @@ const selectWorkspaceFolder = async (): Promise<
 > => {
     const workspaceFolders = getLaravelWorkspaceFolders();
 
-    if (workspaceFolders.length === 0) {
+    if (workspaceFolders.length <= 1) {
         return undefined;
     }
 

--- a/src/commands/goToRoute.ts
+++ b/src/commands/goToRoute.ts
@@ -1,6 +1,9 @@
 import { getRoutes, type RouteItem } from "@src/lsp/routes";
 import { getViews, type ViewItem } from "@src/lsp/views";
-import { getProjectWorkspaceFolders, projectPath } from "@src/support/project";
+import {
+    projectPath,
+    resolveWorkspaceProjectFolders,
+} from "@src/support/project";
 import * as vscode from "vscode";
 import { commandName } from ".";
 
@@ -72,7 +75,7 @@ export const goToRouteCommand = async () => {
 const selectWorkspaceFolder = async (): Promise<
     WorkspaceQuickPickItem | undefined
 > => {
-    const workspaceFolders = getProjectWorkspaceFolders();
+    const workspaceFolders = resolveWorkspaceProjectFolders();
 
     if (workspaceFolders.length <= 1) {
         return undefined;

--- a/src/commands/goToRoute.ts
+++ b/src/commands/goToRoute.ts
@@ -1,6 +1,6 @@
 import { getRoutes, type RouteItem } from "@src/lsp/routes";
 import { getViews, type ViewItem } from "@src/lsp/views";
-import { getLaravelWorkspaceFolders, projectPath } from "@src/support/project";
+import { getProjectWorkspaceFolders, projectPath } from "@src/support/project";
 import * as vscode from "vscode";
 import { commandName } from ".";
 
@@ -72,7 +72,7 @@ export const goToRouteCommand = async () => {
 const selectWorkspaceFolder = async (): Promise<
     WorkspaceQuickPickItem | undefined
 > => {
-    const workspaceFolders = getLaravelWorkspaceFolders();
+    const workspaceFolders = getProjectWorkspaceFolders();
 
     if (workspaceFolders.length <= 1) {
         return undefined;

--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -13,10 +13,10 @@ import { commandName } from ".";
 import { config } from "../support/config";
 import { showErrorPopup } from "../support/popup";
 import {
-    getProjectWorkspaceFolder,
     getWorkspaceFolders,
     projectPath,
     projectPathExists,
+    resolveWorkspaceProjectFolder,
 } from "../support/project";
 
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -154,7 +154,7 @@ export const runPintOnSave = (document: vscode.TextDocument) => {
 
     if (
         !document.uri.fsPath.startsWith(
-            getProjectWorkspaceFolder()?.uri?.fsPath || "",
+            resolveWorkspaceProjectFolder()?.uri?.fsPath || "",
         )
     ) {
         return;

--- a/src/commands/pint.ts
+++ b/src/commands/pint.ts
@@ -13,6 +13,7 @@ import { commandName } from ".";
 import { config } from "../support/config";
 import { showErrorPopup } from "../support/popup";
 import {
+    getProjectWorkspaceFolder,
     getWorkspaceFolders,
     projectPath,
     projectPathExists,
@@ -153,7 +154,7 @@ export const runPintOnSave = (document: vscode.TextDocument) => {
 
     if (
         !document.uri.fsPath.startsWith(
-            getWorkspaceFolders()[0]?.uri?.fsPath || "",
+            getProjectWorkspaceFolder()?.uri?.fsPath || "",
         )
     ) {
         return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ import { collectDebugInfo } from "./support/debug";
 import { disposeWatchers } from "./support/fileWatcher";
 import { info } from "./support/logger";
 import {
-    getLaravelWorkspaceFolders,
+    getProjectWorkspaceFolders,
     hasWorkspace,
     projectPathExists,
 } from "./support/project";
@@ -117,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext) {
     setLspBinaryPath(context);
 
     await Promise.all(
-        getLaravelWorkspaceFolders().map(async (workspaceFolder) => {
+        getProjectWorkspaceFolders().map(async (workspaceFolder) => {
             const lspClient = await startLspClient(workspaceFolder).catch(
                 (error) => {
                     console.error(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,14 @@ import * as vscode from "vscode";
 
 import os from "os";
 import { LanguageClient } from "vscode-languageclient/node";
+import {
+    registerArtisanCommands,
+    registerArtisanMakeCommands,
+} from "./artisan/registry";
 import { bladeSpacer } from "./blade/bladeSpacer";
 import { initClient } from "./blade/client";
 import { commandName, openFileCommand } from "./commands";
+import { configureDockerEnvironment } from "./commands/configureDockerEnvironment";
 import { generateNamespaceCommand } from "./commands/generateNamespace";
 import { goToRouteCommand } from "./commands/goToRoute";
 import {
@@ -30,21 +35,21 @@ import {
     wrapSelectionCommand,
     wrapWithHelperCommands,
 } from "./commands/wrapWithHelper";
+import { setLspBinaryPath } from "./lsp/binary";
+import { restartLspClient, startLspClient, stopLspClient } from "./lsp/client";
+import { clearResolvedPhpCommand, warnAboutLegacyPhpCommand } from "./lsp/php";
+import { checkForLspUpdate, forceLspUpdate } from "./lsp/updater";
 import { configAffected } from "./support/config";
 import { collectDebugInfo } from "./support/debug";
 import { disposeWatchers } from "./support/fileWatcher";
 import { info } from "./support/logger";
-import { restartLspClient, startLspClient, stopLspClient } from "./lsp/client";
-import { setLspBinaryPath } from "./lsp/binary";
-import { clearResolvedPhpCommand, warnAboutLegacyPhpCommand } from "./lsp/php";
-import { checkForLspUpdate, forceLspUpdate } from "./lsp/updater";
-import { hasWorkspace, projectPathExists } from "./support/project";
-import { cleanUpTemp } from "./support/util";
 import {
-    registerArtisanCommands,
-    registerArtisanMakeCommands,
-} from "./artisan/registry";
-import { configureDockerEnvironment } from "./commands/configureDockerEnvironment";
+    getLaravelWorkspaceFolders,
+    hasWorkspace,
+    projectPathExists,
+} from "./support/project";
+import { cleanUpTemp } from "./support/util";
+import { registerTestRunner } from "./test-runner";
 
 let client: LanguageClient;
 
@@ -111,17 +116,24 @@ export async function activate(context: vscode.ExtensionContext) {
 
     setLspBinaryPath(context);
 
-    const lspClient = await startLspClient().catch((error) => {
-        console.error("Failed to start Laravel LSP:", error);
+    await Promise.all(
+        getLaravelWorkspaceFolders().map(async (workspaceFolder) => {
+            const lspClient = await startLspClient(workspaceFolder).catch(
+                (error) => {
+                    console.error(
+                        `Failed to start Laravel LSP for ${workspaceFolder.name}:`,
+                        error,
+                    );
 
-        return undefined;
-    });
+                    return undefined;
+                },
+            );
 
-    if (lspClient) {
-        const { registerTestRunner } = await import("./test-runner/index.js");
-
-        registerTestRunner();
-    }
+            if (lspClient) {
+                registerTestRunner(workspaceFolder);
+            }
+        }),
+    );
 
     void checkForLspUpdate(context);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,9 +44,9 @@ import { collectDebugInfo } from "./support/debug";
 import { disposeWatchers } from "./support/fileWatcher";
 import { info } from "./support/logger";
 import {
-    getProjectWorkspaceFolders,
     hasWorkspace,
     projectPathExists,
+    resolveWorkspaceProjectFolders,
 } from "./support/project";
 import { cleanUpTemp } from "./support/util";
 import { registerTestRunner } from "./test-runner";
@@ -117,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext) {
     setLspBinaryPath(context);
 
     await Promise.all(
-        getProjectWorkspaceFolders().map(async (workspaceFolder) => {
+        resolveWorkspaceProjectFolders().map(async (workspaceFolder) => {
             const lspClient = await startLspClient(workspaceFolder).catch(
                 (error) => {
                     console.error(

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { LanguageClient, Trace } from "vscode-languageclient/node";
+import { LanguageClient } from "vscode-languageclient/node";
 import { getFirstLaravelWorkspaceFolder } from "../support/project";
 import { getLspBinaryPath } from "./binary";
 import { createClientOptions, createServerOptions } from "./options";

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,5 +1,5 @@
 import { LanguageClient } from "vscode-languageclient/node";
-import { getProjectWorkspaceFolder } from "../support/project";
+import { getFirstLaravelWorkspaceFolder } from "../support/project";
 import { getLspBinaryPath } from "./binary";
 import { createClientOptions, createServerOptions } from "./options";
 import { clearResolvedPhpCommand, setResolvedPhpCommand } from "./php";
@@ -23,7 +23,7 @@ export async function startLspClient(): Promise<LanguageClient | undefined> {
         return undefined;
     }
 
-    const workspaceFolder = getProjectWorkspaceFolder();
+    const workspaceFolder = getFirstLaravelWorkspaceFolder();
     const serverOptions = createServerOptions(binaryPath, workspaceFolder);
     const clientOptions = createClientOptions();
 

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 import { LanguageClient } from "vscode-languageclient/node";
-import { getFirstLaravelWorkspaceFolder } from "../support/project";
+import { getFirstProjectWorkspaceFolder } from "../support/project";
 import { getLspBinaryPath } from "./binary";
 import { createClientOptions, createServerOptions } from "./options";
 import { clearResolvedPhpCommand, setResolvedPhpCommand } from "./php";
@@ -15,7 +15,7 @@ type LaravelInitializeResult = {
 };
 
 export async function startLspClient(
-    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
 ): Promise<LanguageClient | undefined> {
     const client = clients.get(workspaceFolder.name);
 
@@ -55,7 +55,7 @@ export async function startLspClient(
 }
 
 export async function stopLspClient(
-    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
 ): Promise<void> {
     clearResolvedPhpCommand();
 
@@ -69,7 +69,7 @@ export async function stopLspClient(
 }
 
 export async function restartLspClient(
-    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
 ): Promise<LanguageClient | undefined> {
     await stopLspClient(workspaceFolder);
 
@@ -79,7 +79,7 @@ export async function restartLspClient(
 export async function sendLspRequest<T>(
     method: string,
     params: object = {},
-    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
 ): Promise<T> {
     const client = clients.get(workspaceFolder.name);
 

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,10 +1,12 @@
-import { LanguageClient } from "vscode-languageclient/node";
+import * as vscode from "vscode";
+
+import { LanguageClient, Trace } from "vscode-languageclient/node";
 import { getFirstLaravelWorkspaceFolder } from "../support/project";
 import { getLspBinaryPath } from "./binary";
 import { createClientOptions, createServerOptions } from "./options";
 import { clearResolvedPhpCommand, setResolvedPhpCommand } from "./php";
 
-let client: LanguageClient | undefined;
+const clients = new Map<string, LanguageClient>();
 
 type LaravelInitializeResult = {
     laravel?: {
@@ -12,7 +14,11 @@ type LaravelInitializeResult = {
     };
 };
 
-export async function startLspClient(): Promise<LanguageClient | undefined> {
+export async function startLspClient(
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): Promise<LanguageClient | undefined> {
+    const client = clients.get(workspaceFolder.name);
+
     if (client) {
         return client;
     }
@@ -23,13 +29,12 @@ export async function startLspClient(): Promise<LanguageClient | undefined> {
         return undefined;
     }
 
-    const workspaceFolder = getFirstLaravelWorkspaceFolder();
     const serverOptions = createServerOptions(binaryPath, workspaceFolder);
-    const clientOptions = createClientOptions();
+    const clientOptions = createClientOptions(workspaceFolder);
 
     const lspClient = new LanguageClient(
         "laravelLsp",
-        "Laravel LSP",
+        `Laravel LSP (${workspaceFolder.name})`,
         serverOptions,
         clientOptions,
     );
@@ -44,29 +49,39 @@ export async function startLspClient(): Promise<LanguageClient | undefined> {
         setResolvedPhpCommand(initializeResult.laravel.phpCommand);
     }
 
-    client = lspClient;
+    clients.set(workspaceFolder.name, lspClient);
 
-    return client;
+    return lspClient;
 }
 
-export async function stopLspClient(): Promise<void> {
+export async function stopLspClient(
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): Promise<void> {
     clearResolvedPhpCommand();
+
+    const client = clients.get(workspaceFolder.name);
 
     if (client) {
         await client.stop();
-        client = undefined;
+
+        clients.delete(workspaceFolder.name);
     }
 }
 
-export async function restartLspClient(): Promise<LanguageClient | undefined> {
-    await stopLspClient();
+export async function restartLspClient(
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): Promise<LanguageClient | undefined> {
+    await stopLspClient(workspaceFolder);
 
-    return startLspClient();
+    return startLspClient(workspaceFolder);
 }
 
 export async function sendLspRequest<T>(
     method: string,
     params: object = {},
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
 ): Promise<T> {
+    const client = clients.get(workspaceFolder.name);
+
     return client!.sendRequest<T>(method, params);
 }

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -25,7 +25,7 @@ export async function startLspClient(): Promise<LanguageClient | undefined> {
 
     const workspaceFolder = getProjectWorkspaceFolder();
     const serverOptions = createServerOptions(binaryPath, workspaceFolder);
-    const clientOptions = createClientOptions(workspaceFolder);
+    const clientOptions = createClientOptions();
 
     const lspClient = new LanguageClient(
         "laravelLsp",

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 import { LanguageClient } from "vscode-languageclient/node";
-import { getFirstProjectWorkspaceFolder } from "../support/project";
+import { resolveWorkspaceProjectFolder } from "../support/project";
 import { getLspBinaryPath } from "./binary";
 import { createClientOptions, createServerOptions } from "./options";
 import { clearResolvedPhpCommand, setResolvedPhpCommand } from "./php";
@@ -15,7 +15,7 @@ type LaravelInitializeResult = {
 };
 
 export async function startLspClient(
-    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<LanguageClient | undefined> {
     const client = clients.get(workspaceFolder.name);
 
@@ -55,7 +55,7 @@ export async function startLspClient(
 }
 
 export async function stopLspClient(
-    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<void> {
     clearResolvedPhpCommand();
 
@@ -69,7 +69,7 @@ export async function stopLspClient(
 }
 
 export async function restartLspClient(
-    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<LanguageClient | undefined> {
     await stopLspClient(workspaceFolder);
 
@@ -79,7 +79,7 @@ export async function restartLspClient(
 export async function sendLspRequest<T>(
     method: string,
     params: object = {},
-    workspaceFolder: vscode.WorkspaceFolder = getFirstProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<T> {
     const client = clients.get(workspaceFolder.name);
 

--- a/src/lsp/models.ts
+++ b/src/lsp/models.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 interface ModelItem {
@@ -6,15 +9,22 @@ interface ModelItem {
 
 type Models = Record<string, ModelItem>;
 
-export const getModels = (): Promise<Models> => {
+export const getModels = (
+    workspaceFolder: vscode.WorkspaceFolder,
+): Promise<Models> => {
     return sendLspRequest<Models>("laravel/data", {
         name: "models",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };
 
-export const getModelClassnames = async (): Promise<Record<string, string>> => {
+export const getModelClassnames = async (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<Record<string, string>> => {
     return Object.fromEntries(
-        Object.values(await getModels()).map((model) => [
+        Object.values(await getModels(workspaceFolder)).map((model) => [
             model.class,
             model.class,
         ]),

--- a/src/lsp/models.ts
+++ b/src/lsp/models.ts
@@ -12,12 +12,13 @@ type Models = Record<string, ModelItem>;
 export const getModels = (
     workspaceFolder: vscode.WorkspaceFolder,
 ): Promise<Models> => {
-    return sendLspRequest<Models>("laravel/data", {
-        name: "models",
-        textDocument: {
-            uri: workspaceFolder.uri.toString(),
+    return sendLspRequest<Models>(
+        "laravel/data",
+        {
+            name: "models",
         },
-    });
+        workspaceFolder,
+    );
 };
 
 export const getModelClassnames = async (

--- a/src/lsp/models.ts
+++ b/src/lsp/models.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { getProjectWorkspaceFolder } from "@src/support/project";
+import { resolveWorkspaceProjectFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 interface ModelItem {
@@ -22,7 +22,7 @@ export const getModels = (
 };
 
 export const getModelClassnames = async (
-    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<Record<string, string>> => {
     return Object.fromEntries(
         Object.values(await getModels(workspaceFolder)).map((model) => [

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -29,6 +29,7 @@ export function createClientOptions(
     workspaceFolder?: vscode.WorkspaceFolder,
 ): LanguageClientOptions {
     return {
+        workspaceFolder,
         documentSelector: [
             { scheme: "file", language: "php" },
             { scheme: "file", language: "blade" },

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -7,7 +7,7 @@ import { config } from "../support/config";
 
 export function createServerOptions(
     binaryPath: string,
-    workspaceFolder: vscode.WorkspaceFolder,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): ServerOptions {
     if (!workspaceFolder) {
         return {

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -7,7 +7,7 @@ import { config } from "../support/config";
 
 export function createServerOptions(
     binaryPath: string,
-    workspaceFolder?: vscode.WorkspaceFolder,
+    workspaceFolder: vscode.WorkspaceFolder,
 ): ServerOptions {
     if (!workspaceFolder) {
         return {
@@ -26,18 +26,25 @@ export function createServerOptions(
 }
 
 export function createClientOptions(
-    workspaceFolder?: vscode.WorkspaceFolder,
+    workspaceFolder: vscode.WorkspaceFolder,
 ): LanguageClientOptions {
+    const path = vscode.workspace.asRelativePath(workspaceFolder.uri, true);
+
     return {
         workspaceFolder,
         documentSelector: [
-            { scheme: "file", language: "php" },
-            { scheme: "file", language: "blade" },
-            { scheme: "file", language: "laravel-blade" },
-            { scheme: "file", pattern: "**/.env*" },
+            { scheme: "file", language: "php", pattern: `${path}/**/*` },
+            { scheme: "file", language: "blade", pattern: `${path}/**/*` },
+            {
+                scheme: "file",
+                language: "laravel-blade",
+                pattern: `${path}/**/*`,
+            },
+            { scheme: "file", pattern: `${path}/**/.env*` },
         ],
-        traceOutputChannel:
-            vscode.window.createOutputChannel("Laravel LSP Trace"),
+        traceOutputChannel: vscode.window.createOutputChannel(
+            `Laravel LSP Trace (${workspaceFolder.name})`,
+        ),
         initializationOptions: {
             appBindingCompletion: config("appBinding.completion", true),
             appBindingDiagnostics: config("appBinding.diagnostics", true),

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -7,15 +7,8 @@ import { config } from "../support/config";
 
 export function createServerOptions(
     binaryPath: string,
-    workspaceFolder?: vscode.WorkspaceFolder,
+    workspaceFolder: vscode.WorkspaceFolder,
 ): ServerOptions {
-    if (!workspaceFolder) {
-        return {
-            command: binaryPath,
-            args: ["lsp"],
-        };
-    }
-
     return {
         command: binaryPath,
         args: ["lsp"],

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -29,7 +29,6 @@ export function createClientOptions(
     workspaceFolder?: vscode.WorkspaceFolder,
 ): LanguageClientOptions {
     return {
-        workspaceFolder,
         documentSelector: [
             { scheme: "file", language: "php" },
             { scheme: "file", language: "blade" },

--- a/src/lsp/options.ts
+++ b/src/lsp/options.ts
@@ -21,19 +21,28 @@ export function createServerOptions(
 export function createClientOptions(
     workspaceFolder: vscode.WorkspaceFolder,
 ): LanguageClientOptions {
-    const path = vscode.workspace.asRelativePath(workspaceFolder.uri, true);
-
     return {
         workspaceFolder,
         documentSelector: [
-            { scheme: "file", language: "php", pattern: `${path}/**/*` },
-            { scheme: "file", language: "blade", pattern: `${path}/**/*` },
+            {
+                scheme: "file",
+                language: "php",
+                pattern: `${workspaceFolder.uri.fsPath}/**/*`,
+            },
+            {
+                scheme: "file",
+                language: "blade",
+                pattern: `${workspaceFolder.uri.fsPath}/**/*`,
+            },
             {
                 scheme: "file",
                 language: "laravel-blade",
-                pattern: `${path}/**/*`,
+                pattern: `${workspaceFolder.uri.fsPath}/**/*`,
             },
-            { scheme: "file", pattern: `${path}/**/.env*` },
+            {
+                scheme: "file",
+                pattern: `${workspaceFolder.uri.fsPath}/**/.env*`,
+            },
         ],
         traceOutputChannel: vscode.window.createOutputChannel(
             `Laravel LSP Trace (${workspaceFolder.name})`,

--- a/src/lsp/paths.ts
+++ b/src/lsp/paths.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { getProjectWorkspaceFolder } from "@src/support/project";
+import { resolveWorkspaceProjectFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface PathItem {
@@ -9,7 +9,7 @@ export interface PathItem {
 }
 
 export const getPaths = (
-    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<PathItem[]> => {
     return sendLspRequest<PathItem[]>(
         "laravel/data",

--- a/src/lsp/paths.ts
+++ b/src/lsp/paths.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface PathItem {
@@ -5,8 +8,13 @@ export interface PathItem {
     path: string;
 }
 
-export const getPaths = (): Promise<PathItem[]> => {
+export const getPaths = (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<PathItem[]> => {
     return sendLspRequest<PathItem[]>("laravel/data", {
         name: "paths",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };

--- a/src/lsp/paths.ts
+++ b/src/lsp/paths.ts
@@ -11,10 +11,11 @@ export interface PathItem {
 export const getPaths = (
     workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
 ): Promise<PathItem[]> => {
-    return sendLspRequest<PathItem[]>("laravel/data", {
-        name: "paths",
-        textDocument: {
-            uri: workspaceFolder.uri.toString(),
+    return sendLspRequest<PathItem[]>(
+        "laravel/data",
+        {
+            name: "paths",
         },
-    });
+        workspaceFolder,
+    );
 };

--- a/src/lsp/routes.ts
+++ b/src/lsp/routes.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { getProjectWorkspaceFolder } from "@src/support/project";
+import { resolveWorkspaceProjectFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface RouteItem {
@@ -15,7 +15,7 @@ export interface RouteItem {
 }
 
 export const getRoutes = (
-    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<RouteItem[]> => {
     return sendLspRequest<RouteItem[]>(
         "laravel/data",

--- a/src/lsp/routes.ts
+++ b/src/lsp/routes.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface RouteItem {
@@ -11,8 +14,13 @@ export interface RouteItem {
     livewire: string | null;
 }
 
-export const getRoutes = (): Promise<RouteItem[]> => {
+export const getRoutes = (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<RouteItem[]> => {
     return sendLspRequest<RouteItem[]>("laravel/data", {
         name: "routes",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };

--- a/src/lsp/routes.ts
+++ b/src/lsp/routes.ts
@@ -17,10 +17,11 @@ export interface RouteItem {
 export const getRoutes = (
     workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
 ): Promise<RouteItem[]> => {
-    return sendLspRequest<RouteItem[]>("laravel/data", {
-        name: "routes",
-        textDocument: {
-            uri: workspaceFolder.uri.toString(),
+    return sendLspRequest<RouteItem[]>(
+        "laravel/data",
+        {
+            name: "routes",
         },
-    });
+        workspaceFolder,
+    );
 };

--- a/src/lsp/updater.ts
+++ b/src/lsp/updater.ts
@@ -1,3 +1,4 @@
+import { getLaravelWorkspaceFolders } from "@src/support/project";
 import * as vscode from "vscode";
 import {
     completeLspBinaryUpdate,
@@ -45,26 +46,43 @@ export async function forceLspUpdate(
                 enqueueLspUpdate(async () => {
                     let result: LspBinaryUpdateResult | undefined;
 
-                    await stopLspClient();
+                    await Promise.all(
+                        getLaravelWorkspaceFolders().map((workspaceFolder) =>
+                            stopLspClient(workspaceFolder),
+                        ),
+                    );
 
                     try {
                         result = await updateLspBinary(context, {
                             force: true,
                         });
 
-                        const updatedClient = await startLspClient();
+                        await Promise.all(
+                            getLaravelWorkspaceFolders().map(
+                                async (workspaceFolder) => {
+                                    const updatedClient =
+                                        await startLspClient(workspaceFolder);
 
-                        if (!updatedClient) {
-                            throw new Error(
-                                "The updated Laravel LSP did not start",
-                            );
-                        }
+                                    if (!updatedClient) {
+                                        throw new Error(
+                                            `The updated Laravel LSP did not start for ${workspaceFolder.name}`,
+                                        );
+                                    }
+                                },
+                            ),
+                        );
                     } catch (error) {
                         if (result?.status === "updated") {
                             await rollbackLspBinaryUpdate(context, result);
                         }
 
-                        await startLspClient();
+                        await Promise.all(
+                            getLaravelWorkspaceFolders().map(
+                                (workspaceFolder) =>
+                                    startLspClient(workspaceFolder),
+                            ),
+                        );
+
                         throw error;
                     }
 

--- a/src/lsp/updater.ts
+++ b/src/lsp/updater.ts
@@ -1,4 +1,4 @@
-import { getProjectWorkspaceFolders } from "@src/support/project";
+import { resolveWorkspaceProjectFolders } from "@src/support/project";
 import * as vscode from "vscode";
 import {
     completeLspBinaryUpdate,
@@ -47,8 +47,8 @@ export async function forceLspUpdate(
                     let result: LspBinaryUpdateResult | undefined;
 
                     await Promise.all(
-                        getProjectWorkspaceFolders().map((workspaceFolder) =>
-                            stopLspClient(workspaceFolder),
+                        resolveWorkspaceProjectFolders().map(
+                            (workspaceFolder) => stopLspClient(workspaceFolder),
                         ),
                     );
 
@@ -58,7 +58,7 @@ export async function forceLspUpdate(
                         });
 
                         await Promise.all(
-                            getProjectWorkspaceFolders().map(
+                            resolveWorkspaceProjectFolders().map(
                                 async (workspaceFolder) => {
                                     const updatedClient =
                                         await startLspClient(workspaceFolder);
@@ -77,7 +77,7 @@ export async function forceLspUpdate(
                         }
 
                         await Promise.all(
-                            getProjectWorkspaceFolders().map(
+                            resolveWorkspaceProjectFolders().map(
                                 (workspaceFolder) =>
                                     startLspClient(workspaceFolder),
                             ),

--- a/src/lsp/updater.ts
+++ b/src/lsp/updater.ts
@@ -1,4 +1,4 @@
-import { getLaravelWorkspaceFolders } from "@src/support/project";
+import { getProjectWorkspaceFolders } from "@src/support/project";
 import * as vscode from "vscode";
 import {
     completeLspBinaryUpdate,
@@ -47,7 +47,7 @@ export async function forceLspUpdate(
                     let result: LspBinaryUpdateResult | undefined;
 
                     await Promise.all(
-                        getLaravelWorkspaceFolders().map((workspaceFolder) =>
+                        getProjectWorkspaceFolders().map((workspaceFolder) =>
                             stopLspClient(workspaceFolder),
                         ),
                     );
@@ -58,7 +58,7 @@ export async function forceLspUpdate(
                         });
 
                         await Promise.all(
-                            getLaravelWorkspaceFolders().map(
+                            getProjectWorkspaceFolders().map(
                                 async (workspaceFolder) => {
                                     const updatedClient =
                                         await startLspClient(workspaceFolder);
@@ -77,7 +77,7 @@ export async function forceLspUpdate(
                         }
 
                         await Promise.all(
-                            getLaravelWorkspaceFolders().map(
+                            getProjectWorkspaceFolders().map(
                                 (workspaceFolder) =>
                                     startLspClient(workspaceFolder),
                             ),

--- a/src/lsp/views.ts
+++ b/src/lsp/views.ts
@@ -1,3 +1,6 @@
+import * as vscode from "vscode";
+
+import { getProjectWorkspaceFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface ViewItem {
@@ -15,8 +18,13 @@ export interface ViewItem {
     };
 }
 
-export const getViews = (): Promise<ViewItem[]> => {
+export const getViews = (
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): Promise<ViewItem[]> => {
     return sendLspRequest<ViewItem[]>("laravel/data", {
         name: "views",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
     });
 };

--- a/src/lsp/views.ts
+++ b/src/lsp/views.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { getProjectWorkspaceFolder } from "@src/support/project";
+import { resolveWorkspaceProjectFolder } from "@src/support/project";
 import { sendLspRequest } from "./client";
 
 export interface ViewItem {
@@ -19,7 +19,7 @@ export interface ViewItem {
 }
 
 export const getViews = (
-    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
 ): Promise<ViewItem[]> => {
     return sendLspRequest<ViewItem[]>(
         "laravel/data",

--- a/src/lsp/views.ts
+++ b/src/lsp/views.ts
@@ -21,10 +21,11 @@ export interface ViewItem {
 export const getViews = (
     workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
 ): Promise<ViewItem[]> => {
-    return sendLspRequest<ViewItem[]>("laravel/data", {
-        name: "views",
-        textDocument: {
-            uri: workspaceFolder.uri.toString(),
+    return sendLspRequest<ViewItem[]>(
+        "laravel/data",
+        {
+            name: "views",
         },
-    });
+        workspaceFolder,
+    );
 };

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -1,6 +1,11 @@
 import { readdirSync } from "fs";
 import * as vscode from "vscode";
-import { getWorkspaceFolders, hasWorkspace } from "./project";
+import {
+    getFirstLaravelWorkspaceFolder,
+    getLaravelWorkspaceFolders,
+    getProjectWorkspaceFolder,
+    getWorkspaceFolders,
+} from "./project";
 import { debounce, leadingDebounce } from "./util";
 
 export type FileEvent = "change" | "create" | "delete";
@@ -10,37 +15,43 @@ let watchers: vscode.FileSystemWatcher[] = [];
 export type WatcherPattern =
     | string
     | string[]
-    | (() => Promise<string | string[] | null>);
+    | ((
+          workspaceFolder: vscode.WorkspaceFolder,
+      ) => Promise<string | string[] | null>);
 
 export const defaultFileEvents: FileEvent[] = ["change", "create", "delete"];
 
 export const loadAndWatch = (
-    load: () => void,
+    load: (workspaceFolder: vscode.WorkspaceFolder) => void,
     patterns: WatcherPattern,
     events: FileEvent[] = defaultFileEvents,
+    workspaceFolder: vscode.WorkspaceFolder,
     reloadOnComposerChanges: boolean = true,
 ): void => {
-    if (!hasWorkspace()) {
-        return;
-    }
+    load(workspaceFolder);
 
-    load();
-
-    const loadFunc = leadingDebounce(load, 1000);
+    const loadFunc = leadingDebounce(() => load(workspaceFolder), 1000);
 
     if (patterns instanceof Function) {
-        patterns().then((result) => {
+        patterns(workspaceFolder).then((result) => {
             if (result !== null) {
                 createFileWatcher(
                     result,
                     loadFunc,
                     events,
+                    workspaceFolder,
                     reloadOnComposerChanges,
                 );
             }
         });
     } else {
-        createFileWatcher(patterns, loadFunc, events, reloadOnComposerChanges);
+        createFileWatcher(
+            patterns,
+            loadFunc,
+            events,
+            workspaceFolder,
+            reloadOnComposerChanges,
+        );
     }
 };
 
@@ -51,7 +62,7 @@ const ignoreDirs = ["node_modules", ".git", "vendor", "storage"];
 export const inAppDirs = (pattern: string) => {
     if (!appDirsRead) {
         appDirsRead = true;
-        readdirSync(getWorkspaceFolders()[0].uri.fsPath, {
+        readdirSync(getProjectWorkspaceFolder()!.uri.fsPath, {
             withFileTypes: true,
         }).forEach((file) => {
             if (file.isDirectory() && !ignoreDirs.includes(file.name)) {
@@ -92,41 +103,48 @@ export const watchForComposerChanges = () => {
         }
     }, 1000);
 
-    const watcher = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(
-            getWorkspaceFolders()[0],
-            "vendor/composer/autoload_*.php",
-        ),
-    );
+    getLaravelWorkspaceFolders().forEach((workspaceFolder) => {
+        const watcher = vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(
+                workspaceFolder,
+                "vendor/composer/autoload_*.php",
+            ),
+        );
 
-    watcher.onDidChange(onChange);
-    watcher.onDidCreate(onChange);
-    watcher.onDidDelete(onChange);
+        watcher.onDidChange(onChange);
+        watcher.onDidCreate(onChange);
+        watcher.onDidDelete(onChange);
 
-    registerWatcher(watcher);
+        registerWatcher(watcher);
+    });
 };
 
 export const createFileWatcher = (
     patterns: string | string[],
     callback: (e: vscode.Uri) => void,
     events: FileEvent[] = defaultFileEvents,
+    workspaceFolder:
+        | vscode.WorkspaceFolder
+        | undefined = getFirstLaravelWorkspaceFolder(),
     reloadOnComposerChanges: boolean = true,
 ): vscode.FileSystemWatcher[] => {
-    if (!hasWorkspace()) {
+    if (!workspaceFolder) {
         return [];
     }
 
     patterns = typeof patterns === "string" ? [patterns] : patterns;
 
     return patterns.map((pattern) => {
-        if (patternWatchers[pattern]) {
-            patternWatchers[pattern].callbacks.push({
+        const key = [workspaceFolder.name, pattern].join(":");
+
+        if (patternWatchers[key]) {
+            patternWatchers[key].callbacks.push({
                 callback,
                 events,
                 reloadOnComposerChanges,
             });
 
-            return patternWatchers[pattern].watcher;
+            return patternWatchers[key].watcher;
         }
 
         const watcher = vscode.workspace.createFileSystemWatcher(
@@ -134,7 +152,7 @@ export const createFileWatcher = (
         );
 
         watcher.onDidChange((...args) => {
-            patternWatchers[pattern].callbacks.forEach((cb) => {
+            patternWatchers[key].callbacks.forEach((cb) => {
                 if (cb.events.includes("change")) {
                     cb.callback(...args);
                 }
@@ -142,7 +160,7 @@ export const createFileWatcher = (
         });
 
         watcher.onDidCreate((...args) => {
-            patternWatchers[pattern].callbacks.forEach((cb) => {
+            patternWatchers[key].callbacks.forEach((cb) => {
                 if (cb.events.includes("create")) {
                     cb.callback(...args);
                 }
@@ -150,14 +168,14 @@ export const createFileWatcher = (
         });
 
         watcher.onDidDelete((...args) => {
-            patternWatchers[pattern].callbacks.forEach((cb) => {
+            patternWatchers[key].callbacks.forEach((cb) => {
                 if (cb.events.includes("delete")) {
                     cb.callback(...args);
                 }
             });
         });
 
-        patternWatchers[pattern] = {
+        patternWatchers[key] = {
             watcher,
             callbacks: [{ callback, events, reloadOnComposerChanges }],
         };

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -4,7 +4,6 @@ import {
     getFirstLaravelWorkspaceFolder,
     getLaravelWorkspaceFolders,
     getProjectWorkspaceFolder,
-    getWorkspaceFolders,
 } from "./project";
 import { debounce, leadingDebounce } from "./util";
 
@@ -148,7 +147,7 @@ export const createFileWatcher = (
         }
 
         const watcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(getWorkspaceFolders()[0], pattern),
+            new vscode.RelativePattern(workspaceFolder, pattern),
         );
 
         watcher.onDidChange((...args) => {

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -1,9 +1,9 @@
 import { readdirSync } from "fs";
 import * as vscode from "vscode";
 import {
-    getFirstLaravelWorkspaceFolder,
-    getLaravelWorkspaceFolders,
+    getFirstProjectWorkspaceFolder,
     getProjectWorkspaceFolder,
+    getProjectWorkspaceFolders,
 } from "./project";
 import { debounce, leadingDebounce } from "./util";
 
@@ -103,7 +103,7 @@ export const watchForComposerChanges = () => {
     }, 1000);
 
     Promise.all(
-        getLaravelWorkspaceFolders().map((workspaceFolder) => {
+        getProjectWorkspaceFolders().map((workspaceFolder) => {
             const watcher = vscode.workspace.createFileSystemWatcher(
                 new vscode.RelativePattern(
                     workspaceFolder,
@@ -126,7 +126,7 @@ export const createFileWatcher = (
     events: FileEvent[] = defaultFileEvents,
     workspaceFolder:
         | vscode.WorkspaceFolder
-        | undefined = getFirstLaravelWorkspaceFolder(),
+        | undefined = getFirstProjectWorkspaceFolder(),
     reloadOnComposerChanges: boolean = true,
 ): vscode.FileSystemWatcher[] => {
     if (!workspaceFolder) {

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -1,9 +1,8 @@
 import { readdirSync } from "fs";
 import * as vscode from "vscode";
 import {
-    getFirstProjectWorkspaceFolder,
-    getProjectWorkspaceFolder,
-    getProjectWorkspaceFolders,
+    resolveWorkspaceProjectFolder,
+    resolveWorkspaceProjectFolders,
 } from "./project";
 import { debounce, leadingDebounce } from "./util";
 
@@ -61,7 +60,7 @@ const ignoreDirs = ["node_modules", ".git", "vendor", "storage"];
 export const inAppDirs = (pattern: string) => {
     if (!appDirsRead) {
         appDirsRead = true;
-        readdirSync(getProjectWorkspaceFolder()!.uri.fsPath, {
+        readdirSync(resolveWorkspaceProjectFolder()!.uri.fsPath, {
             withFileTypes: true,
         }).forEach((file) => {
             if (file.isDirectory() && !ignoreDirs.includes(file.name)) {
@@ -103,7 +102,7 @@ export const watchForComposerChanges = () => {
     }, 1000);
 
     Promise.all(
-        getProjectWorkspaceFolders().map((workspaceFolder) => {
+        resolveWorkspaceProjectFolders().map((workspaceFolder) => {
             const watcher = vscode.workspace.createFileSystemWatcher(
                 new vscode.RelativePattern(
                     workspaceFolder,
@@ -126,7 +125,7 @@ export const createFileWatcher = (
     events: FileEvent[] = defaultFileEvents,
     workspaceFolder:
         | vscode.WorkspaceFolder
-        | undefined = getFirstProjectWorkspaceFolder(),
+        | undefined = resolveWorkspaceProjectFolder(),
     reloadOnComposerChanges: boolean = true,
 ): vscode.FileSystemWatcher[] => {
     if (!workspaceFolder) {

--- a/src/support/fileWatcher.ts
+++ b/src/support/fileWatcher.ts
@@ -102,20 +102,22 @@ export const watchForComposerChanges = () => {
         }
     }, 1000);
 
-    getLaravelWorkspaceFolders().forEach((workspaceFolder) => {
-        const watcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(
-                workspaceFolder,
-                "vendor/composer/autoload_*.php",
-            ),
-        );
+    Promise.all(
+        getLaravelWorkspaceFolders().map((workspaceFolder) => {
+            const watcher = vscode.workspace.createFileSystemWatcher(
+                new vscode.RelativePattern(
+                    workspaceFolder,
+                    "vendor/composer/autoload_*.php",
+                ),
+            );
 
-        watcher.onDidChange(onChange);
-        watcher.onDidCreate(onChange);
-        watcher.onDidDelete(onChange);
+            watcher.onDidChange(onChange);
+            watcher.onDidCreate(onChange);
+            watcher.onDidDelete(onChange);
 
-        registerWatcher(watcher);
-    });
+            registerWatcher(watcher);
+        }),
+    );
 };
 
 export const createFileWatcher = (

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -3,6 +3,10 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { config } from "./config";
 
+type WorkspaceQuickPickItem = vscode.QuickPickItem & {
+    workspaceFolder: vscode.WorkspaceFolder;
+};
+
 const trimFirstSlash = (srcPath: string): string => {
     return srcPath[0] === path.sep ? srcPath.substring(1) : srcPath;
 };
@@ -130,3 +134,31 @@ export const readFileInProject = (
 ): string => {
     return fs.readFileSync(projectPath(path, workspaceFolder), "utf8");
 };
+
+export const selectWorkspaceFolder = async (): Promise<
+    WorkspaceQuickPickItem | undefined
+> => {
+    const workspaceFolders = resolveWorkspaceProjectFolders();
+
+    if (workspaceFolders.length <= 1) {
+        return buildWorkspaceFolderQuickPickItems(workspaceFolders)?.[0];
+    }
+
+    return await vscode.window.showQuickPick(
+        buildWorkspaceFolderQuickPickItems(workspaceFolders),
+        {
+            title: "Laravel: Go to Route",
+            matchOnDescription: false,
+            matchOnDetail: false,
+            placeHolder: "Select a workspace folder to load routes from",
+        },
+    );
+};
+
+const buildWorkspaceFolderQuickPickItems = (
+    workspaceFolders: vscode.WorkspaceFolder[],
+): WorkspaceQuickPickItem[] =>
+    workspaceFolders.map((workspaceFolder) => ({
+        label: workspaceFolder.name,
+        workspaceFolder,
+    }));

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -42,36 +42,64 @@ export const resolveWorkspaceProjectFolder = (
     };
 };
 
-export const getProjectWorkspaceFolder = ():
-    | vscode.WorkspaceFolder
-    | undefined => {
-    const workspaceFolder = getWorkspaceFolders()[0];
+export const getProjectWorkspaceFolder = (
+    uri?: vscode.Uri | undefined,
+): vscode.WorkspaceFolder | undefined => {
+    // Case when we know the file URI and we want to get the VSCode workspace folder for it.
+    // Useful for Laravel artisan commands in the VSCode file explorer
+    if (uri) {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
 
-    if (!workspaceFolder) {
-        return undefined;
+        if (workspaceFolder) {
+            return workspaceFolder;
+        }
     }
 
-    return resolveWorkspaceProjectFolder(workspaceFolder);
+    // Case when we don't know the file URI but we have an active text editor,
+    // so we try to get the workspace folder from it
+    if (vscode.window.activeTextEditor) {
+        const fileUri = vscode.window.activeTextEditor.document.uri;
+
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
+
+        if (workspaceFolder) {
+            return workspaceFolder;
+        }
+    }
+
+    // Fallback, just return the first workspace folder if it exists
+    return getFirstLaravelWorkspaceFolder();
 };
 
-export const projectPath = (srcPath = ""): string => {
+export const getWorkspaceFolders = (): readonly vscode.WorkspaceFolder[] =>
+    vscode.workspace.workspaceFolders || [];
+
+export const getLaravelWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
+    return getWorkspaceFolders().filter((workspaceFolder) =>
+        fs.existsSync(
+            path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
+        ),
+    )!;
+};
+
+export const getFirstLaravelWorkspaceFolder = ():
+    | vscode.WorkspaceFolder
+    | undefined => getLaravelWorkspaceFolders()?.[0];
+
+export const hasWorkspace = (): boolean => {
+    return (
+        getWorkspaceFolders() instanceof Array &&
+        getWorkspaceFolders().length > 0
+    );
+};
+
+export const projectPath = (
+    srcPath = "",
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
+): string => {
     srcPath = basePath(srcPath);
 
-    for (let workspaceFolder of getWorkspaceFolders()) {
-        if (
-            fs.existsSync(
-                path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
-            )
-        ) {
-            return path.join(workspaceFolder.uri.fsPath, srcPath);
-        }
-
-        if (fs.existsSync(path.join(workspaceFolder.uri.fsPath, srcPath))) {
-            return path.join(workspaceFolder.uri.fsPath, srcPath);
-        }
-    }
-
-    return "";
+    return path.join(workspaceFolder.uri.fsPath, srcPath);
 };
 
 export const relativePath = (srcPath: string): string => {
@@ -89,20 +117,16 @@ export const relativePath = (srcPath: string): string => {
     return srcPath;
 };
 
-export const hasWorkspace = (): boolean => {
-    return (
-        vscode.workspace.workspaceFolders instanceof Array &&
-        vscode.workspace.workspaceFolders.length > 0
-    );
+export const projectPathExists = (
+    path: string,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): boolean => {
+    return fs.existsSync(projectPath(path, workspaceFolder));
 };
 
-export const getWorkspaceFolders = () =>
-    vscode.workspace.workspaceFolders || [];
-
-export const projectPathExists = (path: string): boolean => {
-    return fs.existsSync(projectPath(path));
-};
-
-export const readFileInProject = (path: string): string => {
-    return fs.readFileSync(projectPath(path), "utf8");
+export const readFileInProject = (
+    path: string,
+    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+): string => {
+    return fs.readFileSync(projectPath(path, workspaceFolder), "utf8");
 };

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { WorkspaceFolder } from "vscode-languageclient";
 import { config } from "./config";
 
 const trimFirstSlash = (srcPath: string): string => {
@@ -23,8 +22,13 @@ export const resolveWorkspaceProjectPath = (
     return path.resolve(workspaceFolder.uri.fsPath, configuredBasePath);
 };
 
+export const resolveWorkspaceProjectFolders = (): vscode.WorkspaceFolder[] =>
+    getProjectWorkspaceFolders().map((workspaceFolder) =>
+        resolveWorkspaceProjectFolder(workspaceFolder),
+    );
+
 export const resolveWorkspaceProjectFolder = (
-    workspaceFolder: vscode.WorkspaceFolder,
+    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
     configuredBasePath = config<string>("basePath", ""),
 ): vscode.WorkspaceFolder => {
     const projectPath = resolveWorkspaceProjectPath(
@@ -75,21 +79,16 @@ export const getProjectWorkspaceFolder = (
 export const getWorkspaceFolders = (): readonly vscode.WorkspaceFolder[] =>
     vscode.workspace.workspaceFolders || [];
 
-export const getProjectWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
-    return getWorkspaceFolders()
-        .filter((workspaceFolder) =>
-            fs.existsSync(
-                path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
-            ),
-        )
-        .map((workspaceFolder) =>
-            resolveWorkspaceProjectFolder(workspaceFolder),
-        )!;
+const getProjectWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
+    return getWorkspaceFolders().filter((workspaceFolder) =>
+        fs.existsSync(
+            path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
+        ),
+    )!;
 };
 
-export const getFirstProjectWorkspaceFolder = ():
-    | vscode.WorkspaceFolder
-    | undefined => getProjectWorkspaceFolders()?.[0];
+const getFirstProjectWorkspaceFolder = (): vscode.WorkspaceFolder | undefined =>
+    getProjectWorkspaceFolders()?.[0];
 
 export const hasWorkspace = (): boolean => {
     return (
@@ -100,12 +99,8 @@ export const hasWorkspace = (): boolean => {
 
 export const projectPath = (
     srcPath = "",
-    workspaceFolder: vscode.WorkspaceFolder = getProjectWorkspaceFolder()!,
-): string => {
-    srcPath = basePath(srcPath);
-
-    return path.join(workspaceFolder.uri.fsPath, srcPath);
-};
+    workspaceFolder: vscode.WorkspaceFolder = resolveWorkspaceProjectFolder()!,
+): string => path.join(workspaceFolder.uri.fsPath, srcPath);
 
 export const relativePath = (srcPath: string): string => {
     for (let workspaceFolder of getWorkspaceFolders()) {

--- a/src/support/project.ts
+++ b/src/support/project.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
+import { WorkspaceFolder } from "vscode-languageclient";
 import { config } from "./config";
 
 const trimFirstSlash = (srcPath: string): string => {
@@ -68,23 +69,27 @@ export const getProjectWorkspaceFolder = (
     }
 
     // Fallback, just return the first workspace folder if it exists
-    return getFirstLaravelWorkspaceFolder();
+    return getFirstProjectWorkspaceFolder();
 };
 
 export const getWorkspaceFolders = (): readonly vscode.WorkspaceFolder[] =>
     vscode.workspace.workspaceFolders || [];
 
-export const getLaravelWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
-    return getWorkspaceFolders().filter((workspaceFolder) =>
-        fs.existsSync(
-            path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
-        ),
-    )!;
+export const getProjectWorkspaceFolders = (): vscode.WorkspaceFolder[] => {
+    return getWorkspaceFolders()
+        .filter((workspaceFolder) =>
+            fs.existsSync(
+                path.join(workspaceFolder.uri.fsPath, basePath("artisan")),
+            ),
+        )
+        .map((workspaceFolder) =>
+            resolveWorkspaceProjectFolder(workspaceFolder),
+        )!;
 };
 
-export const getFirstLaravelWorkspaceFolder = ():
+export const getFirstProjectWorkspaceFolder = ():
     | vscode.WorkspaceFolder
-    | undefined => getLaravelWorkspaceFolders()?.[0];
+    | undefined => getProjectWorkspaceFolders()?.[0];
 
 export const hasWorkspace = (): boolean => {
     return (
@@ -119,14 +124,14 @@ export const relativePath = (srcPath: string): string => {
 
 export const projectPathExists = (
     path: string,
-    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): boolean => {
     return fs.existsSync(projectPath(path, workspaceFolder));
 };
 
 export const readFileInProject = (
     path: string,
-    workspaceFolder: vscode.WorkspaceFolder = getFirstLaravelWorkspaceFolder()!,
+    workspaceFolder?: vscode.WorkspaceFolder,
 ): string => {
     return fs.readFileSync(projectPath(path, workspaceFolder), "utf8");
 };

--- a/src/support/util.ts
+++ b/src/support/util.ts
@@ -120,7 +120,7 @@ export const waitForValue = <T>(
                 return resolve(value());
             }
 
-            if (value() === null) {
+            if (!value()) {
                 return setTimeout(checkForValue, 100);
             }
 

--- a/src/test-runner/explorer.ts
+++ b/src/test-runner/explorer.ts
@@ -17,21 +17,32 @@ export interface TestSuite {
     }[];
 }
 
-export const updateExplorer = async (controller: vscode.TestController) => {
-    const suites = await getTestSuites();
+export const updateExplorer = async (
+    controller: vscode.TestController,
+    workspaceFolder: vscode.WorkspaceFolder,
+) => {
+    const suites = await getTestSuites(workspaceFolder);
 
     controller.items.replace(
-        suites.map((suite) => buildSuiteItem(controller, suite)),
+        suites.map((suite) =>
+            buildSuiteItem(controller, suite, workspaceFolder),
+        ),
     );
 };
 
-const getTestSuites = () => {
-    return sendLspRequest<TestSuite[]>("laravel/data", { name: "tests" });
+const getTestSuites = (workspaceFolder: vscode.WorkspaceFolder) => {
+    return sendLspRequest<TestSuite[]>("laravel/data", {
+        name: "tests",
+        textDocument: {
+            uri: workspaceFolder.uri.toString(),
+        },
+    });
 };
 
 const buildSuiteItem = (
     controller: vscode.TestController,
     suite: TestSuite,
+    workspaceFolder: vscode.WorkspaceFolder,
 ) => {
     const suiteItem = controller.createTestItem(
         `suite:${suite.name}`,
@@ -40,7 +51,7 @@ const buildSuiteItem = (
     );
 
     suite.files.forEach((file) => {
-        const uri = vscode.Uri.file(projectPath(file.path));
+        const uri = vscode.Uri.file(projectPath(file.path, workspaceFolder));
         const basePath = getBasePath(file.path, file.directories);
 
         const parent = ensureFolderPath(

--- a/src/test-runner/explorer.ts
+++ b/src/test-runner/explorer.ts
@@ -31,12 +31,13 @@ export const updateExplorer = async (
 };
 
 const getTestSuites = (workspaceFolder: vscode.WorkspaceFolder) => {
-    return sendLspRequest<TestSuite[]>("laravel/data", {
-        name: "tests",
-        textDocument: {
-            uri: workspaceFolder.uri.toString(),
+    return sendLspRequest<TestSuite[]>(
+        "laravel/data",
+        {
+            name: "tests",
         },
-    });
+        workspaceFolder,
+    );
 };
 
 const buildSuiteItem = (

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -2,42 +2,41 @@ import * as vscode from "vscode";
 
 import { config } from "@src/support/config";
 import { loadAndWatch } from "@src/support/fileWatcher";
-import { getLaravelWorkspaceFolders } from "@src/support/project";
 import { updateExplorer } from "./explorer";
 import { runHandler } from "./runner";
 
-export const registerTestRunner = async () => {
+export const registerTestRunner = async (
+    workspaceFolder: vscode.WorkspaceFolder,
+) => {
     if (!config("testRunner.enabled", true)) {
         return;
     }
 
-    getLaravelWorkspaceFolders().forEach((workspaceFolder) => {
-        const controller = vscode.tests.createTestController(
-            `${workspaceFolder.name}-tests`,
-            `${workspaceFolder.name} Tests`,
-        );
+    const controller = vscode.tests.createTestController(
+        `${workspaceFolder.name}-tests`,
+        `${workspaceFolder.name} Tests`,
+    );
 
-        controller.createRunProfile(
-            "Run Tests",
-            vscode.TestRunProfileKind.Run,
-            (request, token) =>
-                runHandler(controller, request, token, workspaceFolder),
-            true,
-        );
+    controller.createRunProfile(
+        "Run Tests",
+        vscode.TestRunProfileKind.Run,
+        (request, token) =>
+            runHandler(controller, request, token, workspaceFolder),
+        true,
+    );
 
-        controller.resolveHandler = async (item) => {
-            if (!item) {
-                await updateExplorer(controller, workspaceFolder);
-            }
-        };
+    controller.resolveHandler = async (item) => {
+        if (!item) {
+            await updateExplorer(controller, workspaceFolder);
+        }
+    };
 
-        loadAndWatch(
-            (workspaceFolder) => {
-                void updateExplorer(controller, workspaceFolder);
-            },
-            ["tests/**/*"],
-            ["create", "delete", "change"],
-            workspaceFolder,
-        );
-    });
+    loadAndWatch(
+        (workspaceFolder) => {
+            void updateExplorer(controller, workspaceFolder);
+        },
+        ["tests/**/*"],
+        ["create", "delete", "change"],
+        workspaceFolder,
+    );
 };

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -2,37 +2,42 @@ import * as vscode from "vscode";
 
 import { config } from "@src/support/config";
 import { loadAndWatch } from "@src/support/fileWatcher";
+import { getLaravelWorkspaceFolders } from "@src/support/project";
 import { updateExplorer } from "./explorer";
 import { runHandler } from "./runner";
 
-export const registerTestRunner = () => {
+export const registerTestRunner = async () => {
     if (!config("testRunner.enabled", true)) {
         return;
     }
 
-    const controller = vscode.tests.createTestController(
-        "laravel-tests",
-        "Laravel Tests",
-    );
+    for (const workspaceFolder of getLaravelWorkspaceFolders()) {
+        const controller = vscode.tests.createTestController(
+            `${workspaceFolder.name}-tests`,
+            `${workspaceFolder.name} Tests`,
+        );
 
-    controller.createRunProfile(
-        "Run Tests",
-        vscode.TestRunProfileKind.Run,
-        (request, token) => runHandler(controller, request, token),
-        true,
-    );
+        controller.createRunProfile(
+            "Run Tests",
+            vscode.TestRunProfileKind.Run,
+            (request, token) =>
+                runHandler(controller, request, token, workspaceFolder),
+            true,
+        );
 
-    controller.resolveHandler = async (item) => {
-        if (!item) {
-            await updateExplorer(controller);
-        }
-    };
+        controller.resolveHandler = async (item) => {
+            if (!item) {
+                await updateExplorer(controller, workspaceFolder);
+            }
+        };
 
-    loadAndWatch(
-        () => {
-            void updateExplorer(controller);
-        },
-        ["tests/**/*"],
-        ["create", "delete", "change"],
-    );
+        loadAndWatch(
+            (workspaceFolder) => {
+                void updateExplorer(controller, workspaceFolder);
+            },
+            ["tests/**/*"],
+            ["create", "delete", "change"],
+            workspaceFolder,
+        );
+    }
 };

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -11,7 +11,7 @@ export const registerTestRunner = async () => {
         return;
     }
 
-    for (const workspaceFolder of getLaravelWorkspaceFolders()) {
+    getLaravelWorkspaceFolders().forEach((workspaceFolder) => {
         const controller = vscode.tests.createTestController(
             `${workspaceFolder.name}-tests`,
             `${workspaceFolder.name} Tests`,
@@ -39,5 +39,5 @@ export const registerTestRunner = async () => {
             ["create", "delete", "change"],
             workspaceFolder,
         );
-    }
+    });
 };

--- a/src/test-runner/runner.ts
+++ b/src/test-runner/runner.ts
@@ -1,27 +1,32 @@
-import * as vscode from "vscode";
 import { spawn } from "child_process";
+import * as vscode from "vscode";
 
+import { getPaths, type PathItem } from "@src/lsp/paths";
 import { getPhpCommand } from "@src/lsp/php";
 import { projectPath } from "@src/support/project";
-import { getPaths, type PathItem } from "@src/lsp/paths";
-import { parseLine, buildErrorMessage, TeamcityEvent } from "./teamcity";
+import { buildErrorMessage, parseLine, TeamcityEvent } from "./teamcity";
 
 export const runHandler = async (
     controller: vscode.TestController,
     request: vscode.TestRunRequest,
     token: vscode.CancellationToken,
+    workspaceFolder: vscode.WorkspaceFolder,
 ) => {
     const run = controller.createTestRun(request);
-    const paths = await getPaths();
+    const paths = await getPaths(workspaceFolder);
 
     if (!request.include) {
         const testMap = buildTestMapFromController(controller);
         testMap.forEach((test) => run.enqueued(test));
-        await executeTests([], testMap, run, token, paths);
+        await executeTests([], testMap, run, token, paths, workspaceFolder);
     } else {
         for (const item of request.include) {
-            if (token.isCancellationRequested) break;
-            if (request.exclude?.includes(item)) continue;
+            if (token.isCancellationRequested) {
+                break;
+            }
+            if (request.exclude?.includes(item)) {
+                continue;
+            }
 
             const testMap = buildTestMap(item, request.exclude);
             testMap.forEach((test) => run.enqueued(test));
@@ -31,6 +36,7 @@ export const runHandler = async (
                 run,
                 token,
                 paths,
+                workspaceFolder,
             );
         }
     }
@@ -41,9 +47,15 @@ export const runHandler = async (
 type ItemType = "suite" | "directory" | "file" | "test";
 
 const getItemType = (item: vscode.TestItem): ItemType => {
-    if (item.id.startsWith("suite:")) return "suite";
-    if (item.id.startsWith("dir:")) return "directory";
-    if (item.id.startsWith("file:")) return "file";
+    if (item.id.startsWith("suite:")) {
+        return "suite";
+    }
+    if (item.id.startsWith("dir:")) {
+        return "directory";
+    }
+    if (item.id.startsWith("file:")) {
+        return "file";
+    }
     return "test";
 };
 
@@ -74,7 +86,9 @@ const buildTestMap = (
     const map = new Map<string, vscode.TestItem>();
 
     const collect = (current: vscode.TestItem) => {
-        if (exclude?.includes(current)) return;
+        if (exclude?.includes(current)) {
+            return;
+        }
 
         if (current.children.size === 0) {
             const eventName = getEventName(current);
@@ -117,6 +131,7 @@ const executeTests = async (
     run: vscode.TestRun,
     token: vscode.CancellationToken,
     paths: PathItem[],
+    workspaceFolder: vscode.WorkspaceFolder,
 ): Promise<void> => {
     return new Promise((resolve) => {
         const [executable, ...commandArgs] = [
@@ -129,7 +144,7 @@ const executeTests = async (
         ];
 
         const proc = spawn(executable, commandArgs, {
-            cwd: projectPath(),
+            cwd: projectPath("", workspaceFolder),
             detached: true,
             env: getProcessEnv(),
         });
@@ -194,7 +209,9 @@ const handleEvent = (
 ): void => {
     const test = testMap.get(event.attributes.name);
 
-    if (!test) return;
+    if (!test) {
+        return;
+    }
 
     switch (event.type) {
         case "testStarted":


### PR DESCRIPTION
This PR adds support for multi-root workspaces in the LSP version, similar to my previous PR for native VS Code support: https://github.com/laravel/vs-code-extension/pull/624.

As previously, I tried to modify the code as little as possible. Every method that uses a workspace now has a new workspaceFolder parameter. If a method can use the `workspaceFolder` from `vscode.window.activeTextEditor`, the parameter defaults to `getProjectWorkspaceFolder`.

This PR implements an approach with a separate LSP process for each project in the root workspace. Each project has its own Laravel LSP and Laravel LSP Trace outputs (if enabled).

I added an additional `vscode.window.showQuickPick` for selecting `workspace` in the `goToRouteCommand` and `artisanCommand`.

Tested on Linux and Windows in all modes (single workspace, multi workspace, and without the workspace [using `basePath` only]).

I cannot test it on MacOS, so any feedback would be greatly appreciated.