### PR TITLE
Extend safe-character regex to support Windows paths

### DIFF
--- a/src/support/argv.ts
+++ b/src/support/argv.ts
@@ -3,7 +3,7 @@ const quoteShellArg = (arg: string): string => {
         return "''";
     }
 
-    if (/^[A-Za-z0-9_/:=-]+$/.test(arg)) {
+    if (/^[A-Za-z0-9_/:.\\=-]+$/.test(arg)) {
         return arg;
     }
 


### PR DESCRIPTION
## Problem
The safe-character regex in `quoteShellArg` did not include `.` and `\`, causing Windows paths to be wrapped in single quotes. PowerShell does not support single-quote quoting for executables, which broke all Artisan terminal commands on Windows.

## Fix
This commit extends the regex from `^[A-Za-z0-9_/:=-]+$` to `^[A-Za-z0-9_/:.\\=-]+$` so that typical Windows paths pass through unquoted and are interpreted correctly by PowerShell.