### PR TITLE
Fix Artisan terminal commands break on Windows

### DIFF
--- a/src/support/argv.ts
+++ b/src/support/argv.ts
@@ -11,7 +11,7 @@ const getDefaultTerminal = (): string => {
 
 const quoteShellArg = (arg: string, quote: ShellQuote = "'"): string => {
     if (arg === "") {
-        return "";
+        return "''";
     }
 
     if (/^[A-Za-z0-9_/:=-]+$/.test(arg)) {
@@ -38,10 +38,5 @@ const argvToShell = (argv: string[]): string[] => {
     }
 };
 
-export const argvToShellCommand = (argv: string[]): string => {
-    if (argv.length === 0) {
-        return "";
-    }
-
-    return argvToShell(argv).join(" ");
-};
+export const argvToShellCommand = (argv: string[]): string =>
+    argvToShell(argv).join(" ");

--- a/src/support/argv.ts
+++ b/src/support/argv.ts
@@ -9,26 +9,31 @@ const getDefaultTerminal = (): string => {
     return path.basename(terminal, path.extname(terminal));
 };
 
-const quoteShellArg = (arg: string, quote: ShellQuote = "'"): string => {
+const quoteShellArg = (
+    arg: string,
+    quote: ShellQuote = "'",
+    escapedQuote: string = quote === "'" ? "'\\''" : '\\"',
+): string => {
     if (arg === "") {
-        return "''";
+        return `${quote}${quote}`;
     }
 
     if (/^[A-Za-z0-9_/:=-]+$/.test(arg)) {
         return arg;
     }
 
-    if (quote === "'") {
-        return `'${arg.replace(/'/g, "'\\''")}'`;
-    }
-
-    return `"${arg.replace(/"/g, '\\"')}"`;
+    return `${quote}${arg.replaceAll(quote, escapedQuote)}${quote}`;
 };
 
-const argvToShell = (argv: string[]): string[] => {
-    switch (getDefaultTerminal()) {
+const argvToShell = (argv: string[], terminal: string): string[] => {
+    switch (terminal) {
         case "powershell":
-            return ["&", ...argv.map((arg) => quoteShellArg(arg))];
+        case "pwsh":
+        case "pwsh-preview":
+            return [
+                "&",
+                ...argv.map((arg) => quoteShellArg(arg, "'", "''")),
+            ];
 
         case "cmd":
             return argv.map((arg) => quoteShellArg(arg, '"'));
@@ -38,5 +43,7 @@ const argvToShell = (argv: string[]): string[] => {
     }
 };
 
-export const argvToShellCommand = (argv: string[]): string =>
-    argvToShell(argv).join(" ");
+export const argvToShellCommand = (
+    argv: string[],
+    terminal: string = getDefaultTerminal(),
+): string => argvToShell(argv, terminal).join(" ");

--- a/src/support/argv.ts
+++ b/src/support/argv.ts
@@ -30,10 +30,7 @@ const argvToShell = (argv: string[], terminal: string): string[] => {
         case "powershell":
         case "pwsh":
         case "pwsh-preview":
-            return [
-                "&",
-                ...argv.map((arg) => quoteShellArg(arg, "'", "''")),
-            ];
+            return ["&", ...argv.map((arg) => quoteShellArg(arg, "'", "''"))];
 
         case "cmd":
             return argv.map((arg) => quoteShellArg(arg, '"'));

--- a/src/support/argv.ts
+++ b/src/support/argv.ts
@@ -1,14 +1,47 @@
-const quoteShellArg = (arg: string): string => {
+import path from "path";
+import * as vscode from "vscode";
+
+type ShellQuote = "'" | '"';
+
+const getDefaultTerminal = (): string => {
+    const terminal = vscode.env.shell.toLowerCase();
+
+    return path.basename(terminal, path.extname(terminal));
+};
+
+const quoteShellArg = (arg: string, quote: ShellQuote = "'"): string => {
     if (arg === "") {
-        return "''";
+        return "";
     }
 
     if (/^[A-Za-z0-9_/:=-]+$/.test(arg)) {
         return arg;
     }
 
-    return `'${arg.replace(/'/g, "'\\''")}'`;
+    if (quote === "'") {
+        return `'${arg.replace(/'/g, "'\\''")}'`;
+    }
+
+    return `"${arg.replace(/"/g, '\\"')}"`;
 };
 
-export const argvToShellCommand = (argv: string[]): string =>
-    argv.map(quoteShellArg).join(" ");
+const argvToShell = (argv: string[]): string[] => {
+    switch (getDefaultTerminal()) {
+        case "powershell":
+            return ["&", ...argv.map((arg) => quoteShellArg(arg))];
+
+        case "cmd":
+            return argv.map((arg) => quoteShellArg(arg, '"'));
+
+        default:
+            return argv.map((arg) => quoteShellArg(arg));
+    }
+};
+
+export const argvToShellCommand = (argv: string[]): string => {
+    if (argv.length === 0) {
+        return "";
+    }
+
+    return argvToShell(argv).join(" ");
+};

--- a/src/test/argv.test.ts
+++ b/src/test/argv.test.ts
@@ -1,0 +1,46 @@
+import * as assert from "assert";
+
+import { argvToShellCommand } from "../support/argv";
+
+suite("Shell Argument Test Suite", () => {
+    test("invokes quoted executables in Windows PowerShell", () => {
+        assert.strictEqual(
+            argvToShellCommand(
+                ["C:/Program Files/PHP/php.exe", "artisan"],
+                "powershell",
+            ),
+            "& 'C:/Program Files/PHP/php.exe' artisan",
+        );
+    });
+
+    test("invokes quoted executables in PowerShell 7", () => {
+        assert.strictEqual(
+            argvToShellCommand(
+                ["C:/Program Files/PHP/php.exe", "artisan"],
+                "pwsh",
+            ),
+            "& 'C:/Program Files/PHP/php.exe' artisan",
+        );
+    });
+
+    test("escapes apostrophes in PowerShell arguments", () => {
+        assert.strictEqual(
+            argvToShellCommand(["php", "artisan", "O'Brien"], "pwsh"),
+            "& php artisan 'O''Brien'",
+        );
+    });
+
+    test("preserves POSIX apostrophe escaping", () => {
+        assert.strictEqual(
+            argvToShellCommand(["php", "artisan", "O'Brien"], "bash"),
+            "php artisan 'O'\\''Brien'",
+        );
+    });
+
+    test("quotes empty command prompt arguments", () => {
+        assert.strictEqual(
+            argvToShellCommand(["php", "artisan", ""], "cmd"),
+            'php artisan ""',
+        );
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/laravel/vs-code-extension/issues/700

I'm not a big fan of this implementation, but it works for now. We probably need a proper terminal process adapter, similar to Symfony's Process component for PHP.